### PR TITLE
In place attach

### DIFF
--- a/__workflows/SLURM_CellPose_Segmentation.py
+++ b/__workflows/SLURM_CellPose_Segmentation.py
@@ -138,8 +138,6 @@ def runScript():
                                     values=versions)
             input_list.append(wf_v)
             for i, (k, param) in enumerate(wfparams.items()):
-                logger.debug(f"{i}, {k}, {param}")
-                logging.info(param)
                 p = slurmClient.convert_cytype_to_omtype(
                     param["cytype"],
                     param["default"],

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -476,12 +476,20 @@ def runScript():
                 raise ValueError(version_errors)
             # Check if user actually selected the output option
             selected_output = {}
+            dataset_id_override = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_NEW_DATASET_ID))
+            screen_id_override = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_NEW_SCREEN_ID))
             for output_option in OUTPUT_OPTIONS:
                 selected_op = unwrap(client.getInput(output_option))
                 if (not selected_op) or (
                     selected_op == constants.workflow.NO) or (
                         type(selected_op) == list and constants.workflow.NO in selected_op):
-                    selected_output[output_option] = False
+                    # Still treat as selected if an explicit ID override was given
+                    if output_option == constants.workflow.OUTPUT_NEW_DATASET and dataset_id_override:
+                        selected_output[output_option] = True
+                    elif output_option == constants.workflow.OUTPUT_NEW_SCREEN and screen_id_override:
+                        selected_output[output_option] = True
+                    else:
+                        selected_output[output_option] = False
                 else:
                     selected_output[output_option] = True
                     logger.debug(

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -398,8 +398,6 @@ def runScript():
             # Create a script parameter for all workflow parameters
             for param_incr, (k, param) in enumerate(_workflow_params[
                     wf].items()):
-                logger.debug(f"{param_incr}, {k}, {param}")
-                logger.info(param)
                 # Convert the parameter from cy(tomine)type to om(ero)type
                 omtype_param = slurmClient.convert_cytype_to_omtype(
                     param["cytype"],

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -343,6 +343,14 @@ def runScript():
                            grouping="02.6",
                            description="If a dataset already matches this name, still make a new one?",
                            default=False),
+            omscripts.Long(constants.results.OUTPUT_ATTACH_NEW_DATASET_ID,
+                           optional=True,
+                           grouping="02.61",
+                           description="Pinpoint an exact Dataset by OMERO ID. If provided, this ID wins over name lookup and Allow duplicate settings."),
+            omscripts.Long(constants.results.OUTPUT_ATTACH_NEW_SCREEN_ID,
+                           optional=True,
+                           grouping="02.62",
+                           description="Pinpoint an exact Screen by OMERO ID. If provided, this ID wins over name lookup and Allow duplicate settings."),
             omscripts.Bool(constants.workflow.OUTPUT_CSV_TABLE,
                            optional=False,
                            grouping="02.8",
@@ -1281,6 +1289,10 @@ def importResultsToOmero(client: omscripts.client,
         inputs[
             constants.results.OUTPUT_ATTACH_NEW_DATASET_DUPLICATE
         ] = client.getInput(constants.workflow.OUTPUT_DUPLICATES)
+        # Forward explicit dataset ID if provided (wins over name lookup)
+        dataset_id_override = client.getInput(constants.results.OUTPUT_ATTACH_NEW_DATASET_ID)
+        if dataset_id_override is not None:
+            inputs[constants.results.OUTPUT_ATTACH_NEW_DATASET_ID] = dataset_id_override
 
     else:
         inputs[constants.results.OUTPUT_ATTACH_NEW_DATASET] = rbool(
@@ -1296,6 +1308,10 @@ def importResultsToOmero(client: omscripts.client,
         inputs[
             constants.results.OUTPUT_ATTACH_NEW_SCREEN_DUPLICATE
         ] = client.getInput(constants.workflow.OUTPUT_DUPLICATES)
+        # Forward explicit screen ID if provided (wins over name lookup)
+        screen_id_override = client.getInput(constants.results.OUTPUT_ATTACH_NEW_SCREEN_ID)
+        if screen_id_override is not None:
+            inputs[constants.results.OUTPUT_ATTACH_NEW_SCREEN_ID] = screen_id_override
 
     else:
         inputs[constants.results.OUTPUT_ATTACH_NEW_SCREEN] = rbool(

--- a/__workflows/SLURM_Run_Workflow_Batched.py
+++ b/__workflows/SLURM_Run_Workflow_Batched.py
@@ -133,6 +133,9 @@ def runScript():
         # input and output.
         email_descr = "Do you want an email if your job is done or cancelled?"
 
+        ome_zarr_versions = [rstring(constants.transfer.OME_ZARR_VERSION_0_4),
+                             rstring(constants.transfer.OME_ZARR_VERSION_0_5)]
+
         input_list = [
             omscripts.String(
                 constants.transfer.DATA_TYPE, optional=False, grouping="01.1",
@@ -150,6 +153,15 @@ def runScript():
                           optional=False, grouping="01.4",
                           description="Number of images to send to 1 slurm job",
                           default=32),
+            omscripts.Bool(constants.workflow.USE_ZARR_FORMAT, grouping="01.5",
+                           description="Skip TIFF conversion and run "
+                           "workflows directly on ZARR data (experimental). "
+                           "Use this for workflows that support ZARR input.",
+                           default=False),
+            omscripts.String(
+                            constants.transfer.OME_VERSION, grouping="01.5.1",
+                            description="Ome-zarr version", values=ome_zarr_versions,
+                            default=constants.transfer.OME_ZARR_VERSION_0_4),
             omscripts.Bool(constants.workflow.SELECT_IMPORT,
                            optional=False,
                            grouping="02",
@@ -363,31 +375,53 @@ def runScript():
                                                                 script_params)
                 UI_messages['Message'].extend(
                     [log_message])
-                images = []
-                wells = []
-                for plate in objects:
-                    wells.extend(list(plate.listChildren()))
-                for well in wells:
-                    nr_samples = well.countWellSample()
-                    for index in range(0, nr_samples):
-                        image = well.getImage(index)
-                        images.append(image)
-                if not images:
-                    error = f"No image found in plate(s) {data_ids} / {objects}"
-                    UI_messages['Message'].extend(
-                        [error])
-                    raise ValueError(error)
+                # Zarr plate-to-plate workflows output to a screen.
+                # In that case, keep Data_Type=Plate and batch by plate ID.
+                # Old-school plate workflows (no screen output) expand wells
+                # into individual images and output to a dataset.
+                output_screen = unwrap(client.getInput(
+                    constants.workflow.OUTPUT_NEW_SCREEN))
+                screen_id_override = unwrap(client.getInput(
+                    constants.results.OUTPUT_ATTACH_NEW_SCREEN_ID))
+                use_screen_output = (
+                    output_screen and output_screen != constants.workflow.NO
+                ) or screen_id_override
+                if use_screen_output:
+                    # Plate-to-plate: batch by plate, preserve Data_Type=Plate
+                    if not objects:
+                        error = f"No plates found for IDs {data_ids}"
+                        UI_messages['Message'].extend([error])
+                        raise ValueError(error)
+                    image_ids = [plate.id for plate in objects]
+                    # DATA_TYPE stays Plate — sub-jobs receive Data_Type=Plate
                 else:
+                    # Old-school: expand wells → images, output to dataset
+                    images = []
+                    wells = []
+                    for plate in objects:
+                        wells.extend(list(plate.listChildren()))
+                    for well in wells:
+                        nr_samples = well.countWellSample()
+                        for index in range(0, nr_samples):
+                            image = well.getImage(index)
+                            images.append(image)
+                    if not images:
+                        error = f"No image found in plate(s) {data_ids} / {objects}"
+                        UI_messages['Message'].extend([error])
+                        raise ValueError(error)
                     image_ids = [img.id for img in images]
                     inputs[constants.transfer.DATA_TYPE] = rstring(
                         constants.transfer.DATA_TYPE_IMAGE)
             else:
                 raise ValueError(f"Not recognized input data: {data_type}. \
                     Expected one of {DATATYPES}")
+            # inputs[DATA_TYPE] may have been updated (e.g. plate → image for old-school wells mode)
+            effective_type = unwrap(inputs[constants.transfer.DATA_TYPE]) \
+                if constants.transfer.DATA_TYPE in inputs else data_type
             batch_ids = chunk(image_ids, batch_size)
             batch_ids_list = list(batch_ids)  # Convert generator to list
             logger.info(
-                f"Created {len(batch_ids_list)} batches from {len(image_ids)} images (batch size: {batch_size})")
+                f"Created {len(batch_ids_list)} batches from {len(image_ids)} {data_type}s (batch size: {batch_size})")
 
             # For batching, force duplicate=False so all batches share one dataset/screen.
             # Explicit Dataset_ID / Screen_ID overrides are kept as-is (already in inputs).
@@ -512,7 +546,7 @@ def runScript():
                                 # Add batch supervisor metadata for this completed batch
                                 try:
                                     add_batch_supervisor_metadata_for_batch(
-                                        conn, slurmClient, wf_id, i, batch, len(batch_ids_list), inputs)
+                                        conn, slurmClient, wf_id, i, batch, len(batch_ids_list), inputs, effective_type)
                                 except Exception as e:
                                     logger.warning(
                                         f"Failed to add batch supervisor metadata for batch {i}: {e}")
@@ -578,75 +612,134 @@ def chunk(lst, n):
     return iter(lambda: tuple(islice(it, n)), ())
 
 
-def add_batch_supervisor_metadata_for_batch(conn, slurmClient, supervisor_wf_id, batch_index, batch_image_ids, total_batches, base_inputs):
-    """Add batch supervisor metadata to images from a single completed batch.
+def add_batch_supervisor_metadata_for_batch(conn, slurmClient, supervisor_wf_id, batch_index, batch_ids, total_batches, base_inputs, effective_type=None):
+    """Add batch supervisor metadata to output objects from a single completed batch.
 
-    This function finds output images by matching the input image IDs and output settings
-    that were used for this specific batch, then adds supervisor workflow metadata.
+    For image workflows: annotates output images found via annotation query.
+    For plate workflows: annotates output plates found via annotation query.
 
     Args:
         conn: OMERO BlitzGateway connection
         slurmClient: SlurmClient for accessing workflow tracking
         supervisor_wf_id: UUID of the supervisor (batched) workflow
         batch_index: Index of this specific batch
-        batch_image_ids: List of input image IDs for this batch
+        batch_ids: List of input object IDs (plate IDs or image IDs) for this batch
         total_batches: Total number of batches
         base_inputs: Base input parameters used for all batches
+        effective_type: The data type actually sent to sub-jobs (e.g. 'Plate' or 'Image')
     """
     try:
+        import ezomero
         logger.debug(
             f"Adding batch supervisor metadata for batch {batch_index + 1}/{total_batches}")
 
-        # Extract the output settings that were used for all batches
-        output_settings = {}
-        if constants.workflow.OUTPUT_NEW_DATASET in base_inputs:
-            output_settings['New Dataset'] = unwrap(
-                base_inputs[constants.workflow.OUTPUT_NEW_DATASET])
-        if constants.workflow.OUTPUT_DUPLICATES in base_inputs:
-            output_settings['Allow duplicate?'] = unwrap(
-                base_inputs[constants.workflow.OUTPUT_DUPLICATES])
+        is_plate_mode = (effective_type == constants.transfer.DATA_TYPE_PLATE)
 
-        # Find the corresponding output images for this batch
-        output_images = find_output_images_for_batch(
-            conn, batch_image_ids)
+        if is_plate_mode:
+            # Plate mode: find output plates via annotation query (same as image mode but for Plate objects).
+            object_type = "Plate"
+            ids_key = "Input_Plate_IDs"
+            output_objects = find_output_plates_for_batch(conn, batch_ids)
+        else:
+            # Image mode: find output images via annotation query.
+            object_type = "Image"
+            ids_key = "Input_Image_IDs"
+            output_objects = find_output_images_for_batch(conn, batch_ids)
 
-        if output_images:
-            # Add batch supervisor metadata to found images
+        if output_objects:
             batch_supervisor_dict = {
                 'Batch_Supervisor_Workflow_ID': str(supervisor_wf_id),
                 'Batch_Index': str(batch_index + 1),  # 1-indexed for users
                 'Total_Batches': str(total_batches),
-                # First 10 IDs
-                'Input_Image_IDs': ', '.join(map(str, batch_image_ids[:10])) + ('...' if len(batch_image_ids) > 10 else '')
+                ids_key: ', '.join(map(str, batch_ids[:10])) + ('...' if len(batch_ids) > 10 else '')
             }
 
-            for img_id in output_images:
+            for obj_id in output_objects:
                 try:
-                    import ezomero
                     map_ann_id = ezomero.post_map_annotation(
                         conn=conn,
-                        object_type="Image",
-                        object_id=img_id,
+                        object_type=object_type,
+                        object_id=obj_id,
                         kv_dict=batch_supervisor_dict,
                         ns="biomero/workflow/batch",
                         across_groups=False
                     )
                     logger.debug(
-                        f"Added batch supervisor metadata to image {img_id}")
+                        f"Added batch supervisor metadata to {object_type} {obj_id}")
                 except Exception as e:
                     logger.warning(
-                        f"Failed to add batch supervisor metadata to image {img_id}: {e}")
+                        f"Failed to add batch supervisor metadata to {object_type} {obj_id}: {e}")
 
             logger.debug(
-                f"Added batch supervisor metadata to {len(output_images)} images")
+                f"Added batch supervisor metadata to {len(output_objects)} {object_type}(s)")
         else:
             logger.warning(
-                f"No output images found for batch {batch_index + 1}")
+                f"No output {object_type}(s) found for batch {batch_index + 1}")
 
     except Exception as e:
         logger.error(
             f"Error adding batch supervisor metadata for batch {batch_index + 1}: {e}")
         raise
+
+
+def find_output_plates_for_batch(conn, input_plate_ids):
+    """Find output plates created by a batch using input plate IDs.
+
+    Args:
+        conn: OMERO BlitzGateway connection
+        input_plate_ids: List of input plate IDs for this batch
+
+    Returns:
+        List of output plate IDs created by this batch
+    """
+    try:
+        query_service = conn.getQueryService()
+
+        import datetime
+        from omero.rtypes import rtime
+        cutoff = datetime.datetime.now(
+            datetime.timezone.utc) - datetime.timedelta(minutes=5)
+        params = omero.sys.ParametersI()
+        params.add("cutoff", rtime(int(cutoff.timestamp() * 1000)))
+
+        like_conditions = []
+        for i, plate_id in enumerate(input_plate_ids):
+            param_name = f"id_{i}"
+            like_conditions.append(f"mv.value like :{param_name}")
+            params.addString(param_name, f"%{plate_id}%")
+
+        like_clause = " and ".join(like_conditions)
+
+        hql = f"""
+        select distinct
+            plate.id as output_plate_id,
+            ma.id as annotation_id,
+            mv.value as input_data,
+            ev.time as creation_time
+        from Plate plate
+        join plate.annotationLinks l
+        join l.child ma
+        join ma.details.creationEvent ev
+        join ma.mapValue mvName
+        join ma.mapValue mv
+        where ma.ns = 'biomero/workflow/task/SLURM_Get_Results.py'
+          and mvName.name = 'Name'
+          and (mvName.value = 'SLURM_Get_Results.py' or mvName.value = 'SLURM_Import_Results.py')
+          and mv.name = 'Input_Data'
+          and ev.time > :cutoff
+          and ({like_clause})
+        """
+
+        results = query_service.projection(hql, params)
+
+        output_plate_ids = [result[0].val for result in results]
+        logger.debug(
+            f"Found {len(output_plate_ids)} output plates for batch with {len(input_plate_ids)} input plates")
+        return output_plate_ids
+
+    except Exception as e:
+        logger.error(f"Error finding output plates for batch: {e}")
+        return []
 
 
 def find_output_images_for_batch(conn, input_image_ids):

--- a/__workflows/SLURM_Run_Workflow_Batched.py
+++ b/__workflows/SLURM_Run_Workflow_Batched.py
@@ -300,13 +300,21 @@ def runScript():
                 raise ValueError(version_errors)
             # Check if user actually selected the output option
             selected_output = {}
+            dataset_id_override = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_NEW_DATASET_ID))
+            screen_id_override = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_NEW_SCREEN_ID))
             for output_option in OUTPUT_OPTIONS:
                 selected_op = unwrap(client.getInput(output_option))
                 if (not selected_op) or (
                     selected_op == constants.workflow.NO) or (
                         type(selected_op) == list and
                         constants.workflow.NO in selected_op):
-                    selected_output[output_option] = False
+                    # Still treat as selected if an explicit ID override was given
+                    if output_option == constants.workflow.OUTPUT_NEW_DATASET and dataset_id_override:
+                        selected_output[output_option] = True
+                    elif output_option == constants.workflow.OUTPUT_NEW_SCREEN and screen_id_override:
+                        selected_output[output_option] = True
+                    else:
+                        selected_output[output_option] = False
                 else:
                     selected_output[output_option] = True
             if not any(selected_output.values()):

--- a/__workflows/SLURM_Run_Workflow_Batched.py
+++ b/__workflows/SLURM_Run_Workflow_Batched.py
@@ -66,6 +66,7 @@ DATATYPES = [rstring(constants.transfer.DATA_TYPE_DATASET),
 OUTPUT_OPTIONS = [constants.workflow.OUTPUT_RENAME,
                   constants.workflow.OUTPUT_PARENT,
                   constants.workflow.OUTPUT_NEW_DATASET,
+                  constants.workflow.OUTPUT_NEW_SCREEN,
                   constants.workflow.OUTPUT_ATTACH,
                   constants.workflow.OUTPUT_CSV_TABLE]
 
@@ -173,6 +174,23 @@ def runScript():
                              grouping="02.5",
                              description="Name for the new dataset w/ result images",
                              default=constants.workflow.NO),
+            omscripts.String(constants.workflow.OUTPUT_NEW_SCREEN, optional=True,
+                             grouping="02.5.1",
+                             description="Name for the new screen w/ result images",
+                             default=constants.workflow.NO),
+            omscripts.Bool(constants.workflow.OUTPUT_DUPLICATES,
+                           optional=True,
+                           grouping="02.6",
+                           description="If a dataset already matches this name, still make a new one? (Note: for batched runs this is always False to share one dataset)",
+                           default=False),
+            omscripts.Long(constants.results.OUTPUT_ATTACH_NEW_DATASET_ID,
+                           optional=True,
+                           grouping="02.61",
+                           description="Pinpoint an exact Dataset by OMERO ID. If provided, this ID wins over name lookup and Allow duplicate settings."),
+            omscripts.Long(constants.results.OUTPUT_ATTACH_NEW_SCREEN_ID,
+                           optional=True,
+                           grouping="02.62",
+                           description="Pinpoint an exact Screen by OMERO ID. If provided, this ID wins over name lookup and Allow duplicate settings."),
             omscripts.Bool(constants.workflow.OUTPUT_CSV_TABLE,
                            optional=False,
                            grouping="02.8",
@@ -371,7 +389,8 @@ def runScript():
             logger.info(
                 f"Created {len(batch_ids_list)} batches from {len(image_ids)} images (batch size: {batch_size})")
 
-            # For batching, ensure we write to 1 dataset, not 1 for each batch
+            # For batching, force duplicate=False so all batches share one dataset/screen.
+            # Explicit Dataset_ID / Screen_ID overrides are kept as-is (already in inputs).
             inputs[constants.workflow.OUTPUT_DUPLICATES] = omscripts.rbool(
                 False)
             processes = {}

--- a/_data/SLURM_Get_Results.py
+++ b/_data/SLURM_Get_Results.py
@@ -1021,19 +1021,26 @@ def upload_contents_to_omero(client, conn, slurmClient, message, folder, metadat
             # create a new dataset for new images
             dataset_name = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_NEW_DATASET_NAME))
 
-            create_new_dataset = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_NEW_DATASET_DUPLICATE))
-            if not create_new_dataset:  # check the named dataset first
-                try:
-                    existing_datasets_w_name = [d.id for d in conn.getObjects(
-                        'Dataset',
-                        attributes={"name": dataset_name})]
-                    #  if type(d) == omero.model.ProjectI
-                    if not existing_datasets_w_name:
+            # If an explicit Dataset_ID is provided, use it directly — skip name lookup entirely
+            explicit_dataset_id = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_NEW_DATASET_ID))
+            if explicit_dataset_id:
+                dataset_id = int(explicit_dataset_id)
+                create_new_dataset = False
+                logger.info(f"Using explicit {constants.results.OUTPUT_ATTACH_NEW_DATASET_ID}: {dataset_id} (skipping name lookup)")
+            else:
+                create_new_dataset = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_NEW_DATASET_DUPLICATE))
+                if not create_new_dataset:  # check the named dataset first
+                    try:
+                        existing_datasets_w_name = [d.id for d in conn.getObjects(
+                            'Dataset',
+                            attributes={"name": dataset_name})]
+                        #  if type(d) == omero.model.ProjectI
+                        if not existing_datasets_w_name:
+                            create_new_dataset = True
+                        else:
+                            dataset_id = existing_datasets_w_name[0]
+                    except Exception:
                         create_new_dataset = True
-                    else:
-                        dataset_id = existing_datasets_w_name[0]
-                except Exception:
-                    create_new_dataset = True
 
             if create_new_dataset:  # just create a new dataset
                 dataset = omero.model.DatasetI()
@@ -1110,10 +1117,22 @@ def upload_log_to_omero(client, conn, message, slurm_job_id, projects, file, wf_
         # But you could add this as output if you wanted log instead
         # client.setOutput("File_Annotation", robject(annotation._obj))
 
-        # For now, we choose to add as a weblink button
+        # Build a fully-qualified URL so it works from any browser location.
+        # omero.client.web.host (e.g. "https://omero.example.com/omero/") is
+        # the canonical absolute base; fall back to omero.web.prefix for a
+        # path-absolute URL, then bare path as last resort.
         obj_id = annotation.getFile().getId()
-        url = f"get_original_file/{obj_id}/"
+        try:
+            config = conn.getConfigService()
+            web_host = (config.getConfigValue("omero.client.web.host") or "").rstrip("/")
+            if not web_host:
+                web_prefix = (config.getConfigValue("omero.web.prefix") or "").rstrip("/")
+                web_host = web_prefix  # may still be empty → path-absolute
+        except Exception:
+            web_host = ""
+        url = f"{web_host}/webclient/get_original_file/{obj_id}/"
         client.setOutput("URL", wrap({"type": "URL", "href": url}))
+
 
         for project in projects:
             project.linkAnnotation(annotation)  # link it to project.
@@ -1247,13 +1266,30 @@ def resolve_workflow_id(
         except Exception as e:
             logger.warning(f"Job tracker lookup failed: {e}")
 
-    # Step 4: Consistency validation (fail immediately if inconsistent)
+    # Step 4: Consistency validation
+    # job_tracker can return stale data when SLURM recycles job IDs, so it is
+    # treated as a lower-priority source.  If the authoritative sources
+    # (script_parameter and/or slurm_log) agree with each other, trust them
+    # and only warn about a job_tracker mismatch instead of failing hard.
     if validated_sources:
         unique_ids = set(validated_sources.values())
         if len(unique_ids) > 1:
-            raise RuntimeError(f"Workflow ID inconsistency: {dict(validated_sources)}")
+            authoritative = {k: v for k, v in validated_sources.items()
+                             if k in ('script_parameter', 'slurm_log')}
+            authoritative_ids = set(authoritative.values())
+            if len(authoritative_ids) <= 1 and authoritative:
+                # Authoritative sources agree; job_tracker is likely stale
+                # (SLURM recycles job IDs across workflows)
+                logger.warning(
+                    f"Workflow ID mismatch in job_tracker (likely stale SLURM job ID reuse). "
+                    f"Trusting authoritative sources. All sources: {dict(validated_sources)}")
+                wf_id = list(authoritative.values())[0]
+            else:
+                raise RuntimeError(
+                    f"Workflow ID inconsistency: {dict(validated_sources)}")
+        else:
+            wf_id = list(validated_sources.values())[0]
 
-        wf_id = list(validated_sources.values())[0]
         sources = list(validated_sources.keys())
         logger.info(f"Workflow ID validated across {sources}: {wf_id}")
         return wf_id
@@ -1389,6 +1425,10 @@ def runScript():
                          grouping="06.2",
                          description="If there is already a dataset with this name, still create new one? (True) or add to it? (False) ",
                          default=True),
+            scripts.Long(constants.results.OUTPUT_ATTACH_NEW_DATASET_ID,
+                         optional=True,
+                         grouping="06.25",
+                         description="Pinpoint an exact Dataset by OMERO ID. If provided, this ID wins over name lookup and Allow duplicate settings."),
             scripts.Bool(constants.results.OUTPUT_ATTACH_NEW_DATASET_RENAME,
                          optional=True,
                          grouping="06.3",

--- a/_data/SLURM_Import_Results.py
+++ b/_data/SLURM_Import_Results.py
@@ -882,9 +882,20 @@ def upload_log_to_omero(
         # But you could add this as output if you wanted log instead
         # client.setOutput("File_Annotation", robject(annotation._obj))
 
-        # For now, we choose to add as a weblink button
+        # Build a fully-qualified URL so it works from any browser location.
+        # omero.client.web.host (e.g. "https://omero.example.com/omero/") is
+        # the canonical absolute base; fall back to omero.web.prefix for a
+        # path-absolute URL, then bare path as last resort.
         obj_id = annotation.getFile().getId()
-        url = f"get_original_file/{obj_id}/"
+        try:
+            config = conn.getConfigService()
+            web_host = (config.getConfigValue("omero.client.web.host") or "").rstrip("/")
+            if not web_host:
+                web_prefix = (config.getConfigValue("omero.web.prefix") or "").rstrip("/")
+                web_host = web_prefix  # may still be empty → path-absolute
+        except Exception:
+            web_host = ""
+        url = f"{web_host}/webclient/get_original_file/{obj_id}/"
         client.setOutput("URL", wrap({"type": "URL", "href": url}))
 
         for project in projects:
@@ -2561,17 +2572,25 @@ def process_importer_workflow(
             constants.results.OUTPUT_ATTACH_NEW_SCREEN_NAME))
         create_new_destination = unwrap(client.getInput(
             constants.results.OUTPUT_ATTACH_NEW_SCREEN_DUPLICATE))
+        explicit_destination_id = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_NEW_SCREEN_ID))
     else:
         destination_name = unwrap(client.getInput(
             constants.results.OUTPUT_ATTACH_NEW_DATASET_NAME))
         create_new_destination = unwrap(client.getInput(
             constants.results.OUTPUT_ATTACH_NEW_DATASET_DUPLICATE))
+        explicit_destination_id = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_NEW_DATASET_ID))
     
     logger.info(f"Setting up {destination_type.lower()} '{destination_name}'...")
     destination_id = None
 
+    # If an explicit ID is provided, use it directly — skip name lookup entirely
+    if explicit_destination_id:
+        destination_id = int(explicit_destination_id)
+        create_new_destination = False
+        logger.info(
+            f"Using explicit {destination_type}_ID: {destination_id} (skipping name lookup)")
     # Check if destination exists or create new one
-    if not create_new_destination:
+    elif not create_new_destination:
         try:
             existing_objects_w_name = [d.id for d in conn.getObjects(
                 destination_type, attributes={"name": destination_name})]
@@ -3205,6 +3224,10 @@ def runScript() -> None:
                          grouping="05.2",
                          description="If there is already a dataset with this name, still create new one? (True) or add to it? (False) ",
                          default=False),
+            scripts.Long(constants.results.OUTPUT_ATTACH_NEW_DATASET_ID,
+                         optional=True,
+                         grouping="05.25",
+                         description="Pinpoint an exact Dataset by OMERO ID. If provided, this ID wins over name lookup and Allow duplicate settings."),
             scripts.Bool(constants.results.OUTPUT_ATTACH_NEW_DATASET_RENAME,
                          optional=True,
                          grouping="05.3",
@@ -3230,6 +3253,10 @@ def runScript() -> None:
                          grouping="06.2",
                          description="If there is already a screen with this name, still create new one? (True) or add to it? (False) ",
                          default=False),
+            scripts.Long(constants.results.OUTPUT_ATTACH_NEW_SCREEN_ID,
+                         optional=True,
+                         grouping="06.25",
+                         description="Pinpoint an exact Screen by OMERO ID. If provided, this ID wins over name lookup and Allow duplicate settings."),
             scripts.Bool(constants.results.IMPORT_LABEL_ZARRS,
                          optional=True,
                          grouping="07",

--- a/_data/SLURM_Import_Results.py
+++ b/_data/SLURM_Import_Results.py
@@ -94,6 +94,14 @@ import ezomero
 
 from biomero import SlurmClient, constants
 
+try:
+    from omero_upload import upload_ln_s
+    INPLACE_ATTACHMENTS_AVAILABLE = True
+except ImportError:
+    INPLACE_ATTACHMENTS_AVAILABLE = False
+
+USE_INPLACE_ATTACHMENTS = os.getenv("USE_INPLACE_ATTACHMENTS", "true").lower() == "true"
+
 logger = logging.getLogger(__name__)
 
 # Check if importer is enabled via environment variable
@@ -427,10 +435,8 @@ def saveCSVToOmeroAsTable(
                 if wf_id:
                     description += f" from Workflow {wf_id}"
                 origFName = os.path.join(folder, table_name)
-                csv_file_attachment = conn.createFileAnnfromLocalFile(
-                    csv_path, origFilePathAndName=origFName,
-                    mimetype=mimetype,
-                    ns=namespace, desc=description)
+                csv_file_attachment = create_file_annotation_inplace(
+                    conn, csv_path, mimetype, namespace, description)
 
                 # Ensure the OMERO object is fully loaded
                 if data_type == 'Dataset':
@@ -786,6 +792,54 @@ def cleanup_tmp_files_locally(message: str, folder: str, log_file: str) -> str:
     return message
 
 
+def create_file_annotation_inplace(
+    conn: BlitzGateway,
+    file_path: str,
+    mimetype: str,
+    namespace: str,
+    description: str,
+) -> Any:
+    """Create a FileAnnotation using in-place (symlink) import if available.
+
+    When ``omero_upload`` is installed and ``USE_INPLACE_ATTACHMENTS`` is
+    enabled, the file is registered via a symlink inside the OMERO managed
+    repository so no data is copied.  The managed repository root is read
+    from OMERO's own ``omero.data.dir`` config value; the ``OMERO_DATA_DIR``
+    environment variable is used only as a last-resort fallback.
+    Falls back to a regular byte-copy upload when in-place is unavailable.
+
+    Args:
+        conn: Open OMERO BlitzGateway connection.
+        file_path: Absolute path to the file to register.
+        mimetype: MIME type string (e.g. ``"text/csv"``).
+        namespace: OMERO annotation namespace.
+        description: Human-readable description stored on the annotation.
+
+    Returns:
+        A :class:`omero.gateway.FileAnnotationWrapper` for the new annotation.
+    """
+    if INPLACE_ATTACHMENTS_AVAILABLE and USE_INPLACE_ATTACHMENTS:
+        # Resolve OMERO data dir from server config, fall back to env var
+        try:
+            omero_data_dir = conn.getConfigService().getConfigValue("omero.data.dir")
+        except Exception:
+            omero_data_dir = None
+        if not omero_data_dir:
+            omero_data_dir = os.getenv("OMERO_DATA_DIR", "/OMERO")
+        logger.debug(f"Creating in-place file annotation for {file_path} (data dir: {omero_data_dir})")
+        fo = upload_ln_s(conn.c, file_path, omero_data_dir, mimetype)
+        fa = omero.model.FileAnnotationI()
+        fa.setFile(fo._obj)
+        fa.setNs(rstring(namespace))
+        fa.setDescription(rstring(description))
+        fa = conn.getUpdateService().saveAndReturnObject(fa)
+        return omero.gateway.FileAnnotationWrapper(conn, fa)
+    else:
+        logger.debug(f"Creating regular (upload) file annotation for {file_path}")
+        return conn.createFileAnnfromLocalFile(
+            file_path, mimetype=mimetype, ns=namespace, desc=description)
+
+
 def upload_log_to_omero(
     client: Any,
     conn: BlitzGateway,
@@ -822,9 +876,8 @@ def upload_log_to_omero(
         description = f"Log from SLURM job {slurm_job_id}"
         if wf_id:
             description += f" (Workflow {wf_id})"
-        annotation = conn.createFileAnnfromLocalFile(
-            file, mimetype=mimetype,
-            ns=namespace, desc=description)
+        annotation = create_file_annotation_inplace(
+            conn, file, mimetype, namespace, description)
         # Already have other output in this script
         # But you could add this as output if you wanted log instead
         # client.setOutput("File_Annotation", robject(annotation._obj))
@@ -909,9 +962,8 @@ def upload_metadata_csv_to_omero(
         if wf_id:
             description += f" (Workflow {wf_id})"
 
-        annotation = conn.createFileAnnfromLocalFile(
-            renamed_metadata_file, mimetype=mimetype,
-            ns=namespace, desc=description)
+        annotation = create_file_annotation_inplace(
+            conn, renamed_metadata_file, mimetype, namespace, description)
 
         # Refresh objects to avoid UnloadedEntityException (works for Projects, Plates, Images)
         for obj in projects:
@@ -986,9 +1038,8 @@ def upload_zip_to_omero(
         description = f"Results from SLURM job {slurm_job_id}"
         if wf_id:
             description += f" (Workflow {wf_id})"
-        zip_annotation = conn.createFileAnnfromLocalFile(
-            f"{folder}.zip", mimetype=mimetype,
-            ns=namespace, desc=description)
+        zip_annotation = create_file_annotation_inplace(
+            conn, f"{folder}.zip", mimetype, namespace, description)
 
         client.setOutput("File_Annotation", robject(zip_annotation._obj))
 
@@ -3410,14 +3461,10 @@ def runScript() -> None:
             message += "\nSuccessfully copied logfile."
             logger.info(f"Logfile copied successfully: {log_file}")
 
-            logger.info("Uploading logfile to OMERO...")
-            message = upload_log_to_omero(
-                client, conn, message, slurm_job_id,
-                projects, log_file, wf_id=wf_id)
-
             logger.info("Extracting SLURM results...")
             slurm_data_path, permanent_storage_path, temporary_zip_file_path, filename = (
                 None, None, None, None)
+            extraction_error = None
             try:
                 slurm_data_path, permanent_storage_path, temporary_zip_file_path, filename, message = extract_slurm_results_zip(
                     slurmClient, slurm_job_id, local_tmp_storage, group_name, wf_id, message)
@@ -3427,20 +3474,38 @@ def runScript() -> None:
             except Exception as e:
                 logger.error(f"Failed to extract SLURM results: {e}")
                 message += f"\nFailed to extract SLURM results: {e}"
-                raise e
+                extraction_error = e  # defer raise so log is still uploaded below
 
-            # Copy log file into permanent storage so it lives alongside the results
-            if log_file and permanent_storage_path and os.path.exists(log_file):
+            # Copy log to permanent storage (only possible when extraction succeeded),
+            # then upload from the best available path so the in-place symlink stays valid.
+            # If extraction failed we fall back to the /tmp path so the log is still
+            # attached to OMERO before we re-raise.
+            log_to_upload = log_file  # fallback: tmp path
+            if permanent_storage_path and log_file and os.path.exists(log_file):
                 try:
                     log_dest = os.path.join(
                         permanent_storage_path, os.path.basename(log_file))
                     shutil.copy2(log_file, log_dest)
+                    log_to_upload = log_dest  # prefer permanent path for in-place import
                     logger.info(
                         f"Copied log file to permanent storage: {log_dest}")
                     message += f"\nLog file copied to permanent storage."
                 except Exception as _log_copy_err:
                     logger.warning(
                         f"Failed to copy log file to permanent storage: {_log_copy_err}")
+
+            logger.info("Uploading logfile to OMERO...")
+            try:
+                message = upload_log_to_omero(
+                    client, conn, message, slurm_job_id,
+                    projects, log_to_upload, wf_id=wf_id)
+            except Exception as _log_upload_err:
+                # Log the failure but don't let it shadow a pending extraction error
+                logger.warning(f"Log upload failed: {_log_upload_err}")
+
+            # Always propagate extraction failure, even if log upload also failed
+            if extraction_error:
+                raise extraction_error
 
             # IMPORTER WORKFLOW - Dataset and screen image imports
             if use_importer_for_datasets or use_importer_for_screens:


### PR DESCRIPTION
This pull request introduces several improvements and new features to the SLURM workflow scripts, focusing on enhanced dataset/screen selection flexibility, expanded support for plate-to-plate workflows, and improved batch metadata handling. It also cleans up some logging and refactors the way supervisor metadata is attached to output objects.

**Key changes include:**

### In-Place Import supporting Attachments too now 
* like result .zip or .log or ...
* create_file_annotation_inplace , using `omero_upload`
* dep added in `biomero` lib (PR)

### Enhanced Dataset/Screen Selection
* Added optional parameters to allow users to specify exact OMERO Dataset or Screen IDs for result attachment, which take precedence over name-based lookup and duplicate settings (`OUTPUT_ATTACH_NEW_DATASET_ID`, `OUTPUT_ATTACH_NEW_SCREEN_ID`). This is supported in both standard and batched workflow scripts. [[1]](diffhunk://#diff-27a964e3d3c04afded0e6976f7bbecd34380b4acc2d30e95be7e43d6338c2177R346-R353) [[2]](diffhunk://#diff-27a964e3d3c04afded0e6976f7bbecd34380b4acc2d30e95be7e43d6338c2177R479-R491) [[3]](diffhunk://#diff-27a964e3d3c04afded0e6976f7bbecd34380b4acc2d30e95be7e43d6338c2177R1298-R1301) [[4]](diffhunk://#diff-27a964e3d3c04afded0e6976f7bbecd34380b4acc2d30e95be7e43d6338c2177R1317-R1320) [[5]](diffhunk://#diff-0dddb8086808af89eda841c9fd92de8632811582938fb079ae51fe1e9b85bc7cR189-R205) [[6]](diffhunk://#diff-0dddb8086808af89eda841c9fd92de8632811582938fb079ae51fe1e9b85bc7cR303-R316)

### Improved Plate-to-Plate Workflow Support
* Updated batched workflow logic to support "plate-to-plate" workflows, where output is attached to screens rather than datasets. The script now distinguishes between plate and image workflows, batching by plate ID for plate workflows and by image ID for image workflows. [[1]](diffhunk://#diff-0dddb8086808af89eda841c9fd92de8632811582938fb079ae51fe1e9b85bc7cR386-R406) [[2]](diffhunk://#diff-0dddb8086808af89eda841c9fd92de8632811582938fb079ae51fe1e9b85bc7cL359-R435)

### Batch Supervisor Metadata Refactoring
* Refactored `add_batch_supervisor_metadata_for_batch` to annotate both output images and plates, depending on workflow type. Added a new helper, `find_output_plates_for_batch`, to locate output plates via OMERO annotation queries. [[1]](diffhunk://#diff-0dddb8086808af89eda841c9fd92de8632811582938fb079ae51fe1e9b85bc7cL496-R557) [[2]](diffhunk://#diff-0dddb8086808af89eda841c9fd92de8632811582938fb079ae51fe1e9b85bc7cL562-R752)

### Zarr Format Support Enhancements
* Added options to select OME-Zarr version and to run workflows directly on Zarr data, skipping TIFF conversion (experimental). [[1]](diffhunk://#diff-0dddb8086808af89eda841c9fd92de8632811582938fb079ae51fe1e9b85bc7cR136-R138) [[2]](diffhunk://#diff-0dddb8086808af89eda841c9fd92de8632811582938fb079ae51fe1e9b85bc7cR156-R164)

### Logging and Code Cleanup
* Removed unnecessary debug/info logging of workflow parameters in both `SLURM_CellPose_Segmentation.py` and `SLURM_Run_Workflow.py` for cleaner logs. [[1]](diffhunk://#diff-d18b6557fdb5749609aa6ecff406000e68f43c7c293a701f1bad4b455186fea4L141-L142) [[2]](diffhunk://#diff-27a964e3d3c04afded0e6976f7bbecd34380b4acc2d30e95be7e43d6338c2177L393-L394)

These changes improve flexibility for data output, enable more advanced workflows, and enhance traceability and maintainability of batch jobs.