### PR TITLE
Dev bilayers

### DIFF
--- a/__workflows/SLURM_CellPose_Segmentation.py
+++ b/__workflows/SLURM_CellPose_Segmentation.py
@@ -138,15 +138,7 @@ def runScript():
                                     values=versions)
             input_list.append(wf_v)
             for i, (k, param) in enumerate(wfparams.items()):
-                p = slurmClient.convert_cytype_to_omtype(
-                    param["cytype"],
-                    param["default"],
-                    param["name"],
-                    description=param["description"],
-                    default=param["default"],
-                    grouping=f"03.{i+1}",
-                    optional=param['optional']
-                )
+                p = param
                 input_list.append(p)
         inputs = {
             p._name: p for p in input_list

--- a/__workflows/SLURM_CellPose_Segmentation.py
+++ b/__workflows/SLURM_CellPose_Segmentation.py
@@ -140,10 +140,10 @@ def runScript():
             for i, (k, param) in enumerate(wfparams.items()):
                 p = slurmClient.convert_param_type_to_omtype(
                     param["type"],
-                    param["default-value"],
+                    param["default"],
                     param["name"],
                     description=param["description"],
-                    default=param["default-value"],
+                    default=param["default"],
                     grouping=f"03.{i+1}",
                     optional=param['optional']
                 )

--- a/__workflows/SLURM_CellPose_Segmentation.py
+++ b/__workflows/SLURM_CellPose_Segmentation.py
@@ -51,7 +51,7 @@ from biomero import SlurmClient, constants
 import logging
 
 # Version constant for easy version management
-VERSION = "2.6.0"
+VERSION = "2.7.0"
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +102,8 @@ def runScript():
 
         _versions, _datafiles = slurmClient.get_image_versions_and_data_files(
             'cellpose')
-        _workflow_params = slurmClient.get_workflow_parameters('cellpose')
+        _all_wf_params = slurmClient.get_workflow_parameters('cellpose')
+        _workflow_params = {k: v for k, v in _all_wf_params.items() if not v['file_attachment']}
         logger.debug(_workflow_params)
         name_descr = f"Name of folder where images are stored, as provided\
             with {constants.IMAGE_EXPORT_SCRIPT}"

--- a/__workflows/SLURM_CellPose_Segmentation.py
+++ b/__workflows/SLURM_CellPose_Segmentation.py
@@ -138,7 +138,15 @@ def runScript():
                                     values=versions)
             input_list.append(wf_v)
             for i, (k, param) in enumerate(wfparams.items()):
-                p = param
+                p = slurmClient.convert_param_type_to_omtype(
+                    param["type"],
+                    param["default-value"],
+                    param["name"],
+                    description=param["description"],
+                    default=param["default-value"],
+                    grouping=f"03.{i+1}",
+                    optional=param['optional']
+                )
                 input_list.append(p)
         inputs = {
             p._name: p for p in input_list

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -382,13 +382,13 @@ def runScript():
             # Get the workflow parameters (dynamically) from their repository
             _workflow_params[wf] = slurmClient.get_workflow_parameters(
                 wf)
-            json_descriptor = slurmClient.generic_descriptor_from_github(wf)
-            wf_descr = json_descriptor['description']
+            descriptor = slurmClient.generic_descriptor_from_github(wf)
+            wf_descr = descriptor['description']
             # Build value-choices lookup from the descriptor (scoped per wf,
             # so param name collisions across workflows are not an issue)
             value_choices_map = {
                 inp['id']: [rstring(v) for v in inp['value-choices']]
-                for inp in json_descriptor.get('inputs', [])
+                for inp in descriptor.get('inputs', [])
                 if inp.get('value-choices')
             }
             # Main parameter to select this workflow for execution

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -408,10 +408,10 @@ def runScript():
                 # Convert the parameter type to om(ero)type
                 omtype_param = slurmClient.convert_param_type_to_omtype(
                     param["type"],
-                    param["default-value"],
+                    param["default"],
                     param["name"],
                     description=param["description"],
-                    default=param["default-value"],
+                    default=param["default"],
                     grouping=f"{parameter_group}.{param_incr+1}",
                     optional=param['optional'],
                     **({"values": value_choices_map[k]} if k in value_choices_map else {})

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -93,7 +93,7 @@ OUTPUT_OPTIONS = [constants.workflow.OUTPUT_RENAME,
                   constants.workflow.OUTPUT_NEW_SCREEN,
                   constants.workflow.OUTPUT_ATTACH,
                   constants.workflow.OUTPUT_CSV_TABLE]
-VERSION = "2.6.0"
+VERSION = "2.7.0"
 
 
 def validate_importer_write_access(slurmClient: SlurmClient, conn: BlitzGateway, client: omscripts.client) -> None:
@@ -367,6 +367,7 @@ def runScript():
         (wf_versions, _) = slurmClient.get_all_image_versions_and_data_files()
         na = ["Not Available!"]
         _workflow_params = {}
+        _workflow_file_params = {}  # file-attachment params keyed by param_id
         _workflow_available_versions = {}
         # All currently configured workflows
         workflows = wf_versions.keys()
@@ -380,8 +381,9 @@ def runScript():
             _workflow_available_versions[wf] = wf_versions.get(
                 wf, na)
             # Get the workflow parameters (dynamically) from their repository
-            _workflow_params[wf] = slurmClient.get_workflow_parameters(
-                wf)
+            _all_wf_params = slurmClient.get_workflow_parameters(wf)
+            _workflow_params[wf] = {k: v for k, v in _all_wf_params.items() if not v['file_attachment']}
+            _workflow_file_params[wf] = {k: v for k, v in _all_wf_params.items() if v['file_attachment']}
             descriptor = slurmClient.generic_descriptor_from_github(wf)
             wf_descr = descriptor['description']
             # Build value-choices lookup from the descriptor (scoped per wf,
@@ -421,6 +423,22 @@ def runScript():
                 # them to BIOMERO (as the wf will not understand these params)
                 omtype_param._name = f"{wf}_|_{omtype_param._name}"
                 input_list.append(omtype_param)
+            # File-attachment params: exposed as Long (OMERO FileAnnotation ID)
+            # They live under a FILE_ prefix so run_workflow can tell them apart.
+            num_reg = len(_workflow_params[wf])
+            for fp_incr, (k, fp) in enumerate(_workflow_file_params[wf].items()):
+                fmt_str = ", ".join(fp['format']) if fp['format'] else "any"
+                fp_param = omscripts.Long(
+                    f"{wf}_|_FILE_{k}",
+                    optional=fp['optional'],
+                    grouping=f"{parameter_group}.{num_reg + fp_incr + 1}",
+                    description=(
+                        f"[{fp['type'].capitalize()} attachment] {fp['description']}"
+                        f" Accepted formats: {fmt_str}."
+                        f" Provide the OMERO FileAnnotation ID."
+                    ),
+                )
+                input_list.append(fp_param)
         # Finish setting up the Omero script UI
         inputs = {
             f"{p._name}": p for p in input_list
@@ -601,7 +619,9 @@ def runScript():
                         UI_messages, slurm_job_id, wf_id, task_id = run_workflow(
                             slurmClient,
                             _workflow_params[wf_name],
+                            _workflow_file_params[wf_name],
                             client,
+                            conn,
                             UI_messages,
                             zipfile,
                             email,
@@ -751,7 +771,9 @@ def runScript():
 
 def run_workflow(slurmClient: SlurmClient,
                  workflow_params,
+                 file_params,
                  client,
+                 conn,
                  UI_messages: str,
                  zipfile,
                  email,
@@ -761,14 +783,17 @@ def run_workflow(slurmClient: SlurmClient,
 
     Submits a named workflow to SLURM with user-specified parameters and
     monitors initial job submission status. Handles parameter extraction
-    from OMERO UI inputs and manages workflow tracking state.
+    from OMERO UI inputs, file-attachment transfers to HPC, and workflow
+    tracking state.
 
     Args:
         slurmClient (SlurmClient): Active SLURM client connection.
-        workflow_params: Dictionary of workflow-specific parameters.
+        workflow_params: Dictionary of regular workflow parameters.
+        file_params: Dictionary of file-attachment params (annotation IDs).
         client: OMERO script client for parameter access.
+        conn: OMERO BlitzGateway connection (needed for file transfers).
         UI_messages (str): Accumulated user interface messages.
-        zipfile: Name of input data file on SLURM.
+        zipfile: Name of input data file on SLURM (determines data_path).
         email: User email for job notifications.
         name: Workflow name to execute.
         wf_id: Workflow UUID for tracking.
@@ -784,12 +809,70 @@ def run_workflow(slurmClient: SlurmClient,
     logger.info(f"Submitting workflow: {name}")
     workflow_version = unwrap(client.getInput(f"{name}_Version"))
 
-    # Extract workflow parameters
+    # Extract regular workflow parameters
     kwargs = {}
     for k in workflow_params:
         kwargs[k] = unwrap(client.getInput(f"{name}_|_{k}"))
 
-    logger.debug(f"Workflow parameters: {kwargs}")
+    # Transfer file-attachment inputs to HPC and resolve their Slurm paths
+    if file_params:
+        logger.info('''
+        # ------------------------------------------------
+        # :: 1b. Transfer file attachments to Slurm ::
+        # ------------------------------------------------
+        ''')
+        svc = conn.getScriptService()
+        scripts = svc.getScripts()
+        file_transfer_scripts = [constants.FILE_TRANSFER_SCRIPT]
+        ft_matches = [(unwrap(s.id), unwrap(s.getName()))
+                      for s in scripts if unwrap(s.getName()) in file_transfer_scripts]
+        if not ft_matches:
+            logger.warning(
+                f"File transfer script {file_transfer_scripts} not found — "
+                f"skipping file-attachment transfer for {name}."
+            )
+        else:
+            ft_script_id, ft_script_name = ft_matches[0]
+            for param_id, fp in file_params.items():
+                ann_id = unwrap(client.getInput(f"{name}_|_FILE_{param_id}"))
+                if ann_id is None:
+                    if not fp['optional']:
+                        err = f"Required file attachment '{param_id}' has no annotation ID — cannot run workflow."
+                        logger.error(err)
+                        raise ValueError(err)
+                    logger.debug(f"No annotation ID supplied for optional param '{param_id}', skipping.")
+                    continue
+                logger.info(f"Transferring file attachment {ann_id} for param '{param_id}'")
+                ft_inputs = {
+                    constants.file_transfer.FILE_ANNOTATION_ID: rlong(ann_id),
+                    constants.file_transfer.FOLDER: rstring(zipfile),
+                    constants.CLEANUP: client.getInput(constants.CLEANUP) or rbool(True),
+                }
+                try:
+                    ft_task_id = slurmClient.workflowTracker.add_task_to_workflow(
+                        wf_id, ft_script_name, VERSION,
+                        ann_id, {k: unwrap(v) for k, v in ft_inputs.items()}
+                    )
+                    slurmClient.workflowTracker.start_task(ft_task_id)
+                except Exception as db_e:
+                    logger.error(f"DB error adding file-transfer task: {db_e}")
+                    raise
+                ft_rv, _ = runOMEROScript(client, svc, ft_script_id, ft_inputs,
+                                           slurmClient=slurmClient)
+                slurm_path = unwrap(ft_rv.get('Slurm_Path')) if ft_rv else None
+                ft_msg = unwrap(ft_rv.get('Message', None)) if ft_rv else ''
+                if slurm_path:
+                    kwargs[param_id] = slurm_path
+                    UI_messages += f"Transferred {fp['type']} '{param_id}' to {slurm_path}. "
+                    slurmClient.workflowTracker.complete_task(ft_task_id, ft_msg or slurm_path)
+                else:
+                    err = f"File transfer for '{param_id}' (ann {ann_id}) returned no path: {ft_msg}"
+                    logger.warning(err)
+                    slurmClient.workflowTracker.fail_task(ft_task_id, err)
+                    if not fp.get('optional', True):
+                        raise ValueError(err)
+
+    logger.debug(f"Workflow parameters (incl. file paths): {kwargs}")
     try:
         # Pre-flight: verify the job script exists on Slurm before submitting
         configured_job = slurmClient.slurm_model_jobs.get(name.lower())

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -92,7 +92,8 @@ OUTPUT_OPTIONS = [constants.workflow.OUTPUT_RENAME,
                   constants.workflow.OUTPUT_NEW_DATASET,
                   constants.workflow.OUTPUT_NEW_SCREEN,
                   constants.workflow.OUTPUT_ATTACH,
-                  constants.workflow.OUTPUT_CSV_TABLE]
+                  constants.workflow.OUTPUT_CSV_TABLE,
+                  constants.workflow.OUTPUT_ATTACH_FILE_OUTPUTS]
 VERSION = "2.7.0"
 
 
@@ -356,6 +357,11 @@ def runScript():
                            grouping="02.8",
                            description="Any resulting csv files will be added as OMERO.table to parent dataset/plate",
                            default=True),
+            omscripts.Bool(constants.workflow.OUTPUT_ATTACH_FILE_OUTPUTS,
+                           optional=True,
+                           grouping="02.85",
+                           description="Attach individual non-image output files (arrays, model weights, configs) as OMERO file annotations. Useful for bilayers workflows with 'array', 'file', or 'executable' output types.",
+                           default=False),
             omscripts.Bool(constants.CLEANUP,
                            optional=True,
                            grouping="02.9", 
@@ -1516,6 +1522,10 @@ def importResultsToOmero(client: omscripts.client,
     inputs[constants.results.IMPORT_LABEL_ZARRS] = rbool(True)
     inputs[constants.results.IMPORT_ONLY_LABELS] = rbool(True)
     inputs[constants.results.TEST_WRITE_PERMISSIONS_ONLY] = rbool(False)
+
+    # Forward file-output annotation flag
+    inputs[constants.results.OUTPUT_ATTACH_FILE_OUTPUTS] = rbool(
+        selected_output.get(constants.workflow.OUTPUT_ATTACH_FILE_OUTPUTS, False))
 
     # Wait for Slurm Accounting to update
     wait_for_job_completion(slurmClient, slurm_job_id)

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -792,7 +792,12 @@ def run_workflow(slurmClient: SlurmClient,
     logger.debug(f"Workflow parameters: {kwargs}")
     try:
         # Pre-flight: verify the job script exists on Slurm before submitting
-        job_script = f"{slurmClient.slurm_script_path}/jobs/{name}.sh"
+        configured_job = slurmClient.slurm_model_jobs.get(name.lower())
+        job_script = (
+            f"{slurmClient.slurm_script_path}/{configured_job}"
+            if configured_job
+            else f"{slurmClient.slurm_script_path}/jobs/{name}.sh"
+        )
         check_result = slurmClient.run(f'test -f "{job_script}"', warn=True)
         if check_result.exited != 0:
             raise FileNotFoundError(

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -405,8 +405,17 @@ def runScript():
             # Create a script parameter for all workflow parameters
             for param_incr, (k, param) in enumerate(_workflow_params[
                     wf].items()):
-                # Convert the parameter from cy(tomine)type to om(ero)type
-                omtype_param = param
+                # Convert the parameter type to om(ero)type
+                omtype_param = slurmClient.convert_param_type_to_omtype(
+                    param["type"],
+                    param["default-value"],
+                    param["name"],
+                    description=param["description"],
+                    default=param["default-value"],
+                    grouping=f"{parameter_group}.{param_incr+1}",
+                    optional=param['optional'],
+                    **({"values": value_choices_map[k]} if k in value_choices_map else {})
+                )
                 # To allow 'duplicate' params, add the wf to uniqueify them
                 # we have to remove this prefix later again, before passing
                 # them to BIOMERO (as the wf will not understand these params)

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -833,7 +833,8 @@ def run_workflow(slurmClient: SlurmClient,
             )
         else:
             ft_script_id, ft_script_name = ft_matches[0]
-            for param_id, fp in file_params.items():
+            for slot_index, (param_id, fp) in enumerate(file_params.items(), start=1):
+                param_slot = f"p{slot_index}"
                 raw = unwrap(client.getInput(f"{name}_|_FILE_{param_id}"))
                 # Normalise: single int or list of ints → always a list
                 if raw is None:
@@ -853,10 +854,14 @@ def run_workflow(slurmClient: SlurmClient,
 
                 collected_paths = []
                 for ann_id in ann_ids:
-                    logger.info(f"Transferring file attachment {ann_id} for param '{param_id}'")
+                    logger.info(
+                        f"Transferring file attachment {ann_id} for "
+                        f"param slot '{param_slot}'"
+                    )
                     ft_inputs = {
                         constants.file_transfer.FILE_ANNOTATION_ID: rlong(ann_id),
                         constants.file_transfer.FOLDER: rstring(zipfile),
+                        constants.file_transfer.PARAM_SLOT: rstring(param_slot),
                         constants.CLEANUP: client.getInput(constants.CLEANUP) or rbool(True),
                     }
                     if fp.get('format'):
@@ -878,18 +883,27 @@ def run_workflow(slurmClient: SlurmClient,
                     ft_msg = unwrap(ft_rv.get('Message', None)) if ft_rv else ''
                     if slurm_path:
                         collected_paths.append(slurm_path)
-                        UI_messages += f"Transferred {fp['type']} '{param_id}' to {slurm_path}. "
+                        UI_messages += (
+                            f"Transferred {fp['type']} '{param_id}' "
+                            f"as {param_slot} to {slurm_path}. "
+                        )
                         slurmClient.workflowTracker.complete_task(ft_task_id, ft_msg or slurm_path)
                     else:
-                        err = f"File transfer for '{param_id}' (ann {ann_id}) returned no path: {ft_msg}"
+                        err = (
+                            f"File transfer for '{param_id}' "
+                            f"({param_slot}, ann {ann_id}) returned no path: {ft_msg}"
+                        )
                         logger.warning(err)
                         slurmClient.workflowTracker.fail_task(ft_task_id, err)
                         if not fp.get('optional', True):
                             raise ValueError(err)
 
                 if collected_paths:
-                    # Space-separated when multiple files; single value otherwise
-                    kwargs[param_id] = " ".join(collected_paths)
+                    # Attachments are routed into param-specific dirs on SLURM
+                    # (e.g. .../data/in/<param_id>/). Pass that directory to
+                    # the workflow CLI flag for consistent handling across
+                    # single and multiple file-count params.
+                    kwargs[param_id] = os.path.dirname(collected_paths[0])
 
     logger.debug(f"Workflow parameters (incl. file paths): {kwargs}")
     try:

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -406,16 +406,7 @@ def runScript():
             for param_incr, (k, param) in enumerate(_workflow_params[
                     wf].items()):
                 # Convert the parameter from cy(tomine)type to om(ero)type
-                omtype_param = slurmClient.convert_cytype_to_omtype(
-                    param["cytype"],
-                    param["default"],
-                    param["name"],
-                    description=param["description"],
-                    default=param["default"],
-                    grouping=f"{parameter_group}.{param_incr+1}",
-                    optional=param['optional'],
-                    **({"values": value_choices_map[k]} if k in value_choices_map else {})
-                )
+                omtype_param = param
                 # To allow 'duplicate' params, add the wf to uniqueify them
                 # we have to remove this prefix later again, before passing
                 # them to BIOMERO (as the wf will not understand these params)

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -413,7 +413,7 @@ def runScript():
                     description=param["description"],
                     default=param["default"],
                     grouping=f"{parameter_group}.{param_incr+1}",
-                    optional=param['optional'],
+                    optional=True,  # always optional: params from other workflows must not block this one
                     **({"values": value_choices_map[k]} if k in value_choices_map else {})
                 )
                 # To allow 'duplicate' params, add the wf to uniqueify them
@@ -616,12 +616,12 @@ def runScript():
 
                 while slurm_job_id_list:
                     # Query all jobids we care about
+                    job_status_dict = {}
                     try:
                         job_status_dict, _ = slurmClient.check_job_status(
                             slurm_job_id_list)
                     except Exception as e:
-                        UI_messages += f" ERROR WITH JOB: {e}"
-                        wf_failed = True
+                        logger.warning(f"Transient error checking job status, will retry: {e}")
 
                     for slurm_job_id, job_state in job_status_dict.items():
                         logger.debug(f"Job {slurm_job_id} is {job_state}.")
@@ -791,6 +791,16 @@ def run_workflow(slurmClient: SlurmClient,
 
     logger.debug(f"Workflow parameters: {kwargs}")
     try:
+        # Pre-flight: verify the job script exists on Slurm before submitting
+        job_script = f"{slurmClient.slurm_script_path}/jobs/{name}.sh"
+        check_result = slurmClient.run(f'test -f "{job_script}"', warn=True)
+        if check_result.exited != 0:
+            raise FileNotFoundError(
+                f"Job script not found on Slurm: {job_script}. "
+                f"Please generate the job script for '{name}' first "
+                f"(use 'Validate Slurm Setup' or check your slurm-scripts repo)."
+            )
+
         cp_result, slurm_job_id, wf_id, task_id = slurmClient.run_workflow(
             workflow_name=name,
             workflow_version=workflow_version,

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -423,21 +423,21 @@ def runScript():
                 # them to BIOMERO (as the wf will not understand these params)
                 omtype_param._name = f"{wf}_|_{omtype_param._name}"
                 input_list.append(omtype_param)
-            # File-attachment params: exposed as Long (OMERO FileAnnotation ID)
+            # File-attachment params: exposed as List(Long) of OMERO FileAnnotation IDs
             # They live under a FILE_ prefix so run_workflow can tell them apart.
             num_reg = len(_workflow_params[wf])
             for fp_incr, (k, fp) in enumerate(_workflow_file_params[wf].items()):
                 fmt_str = ", ".join(fp['format']) if fp['format'] else "any"
-                fp_param = omscripts.Long(
+                fp_param = omscripts.List(
                     f"{wf}_|_FILE_{k}",
-                    optional=True,  # always optional: required-ness is enforced per chosen workflow at runtime
+                    optional=True,  # required-ness is enforced per selected workflow at runtime
                     grouping=f"{parameter_group}.{num_reg + fp_incr + 1}",
                     description=(
                         f"[{fp['type'].capitalize()} attachment] {fp['description']}"
                         f" Accepted formats: {fmt_str}."
-                        f" Provide the OMERO FileAnnotation ID."
+                        f" Provide one or more OMERO FileAnnotation IDs."
                     ),
-                )
+                ).ofType(rlong(0))
                 input_list.append(fp_param)
         # Finish setting up the Omero script UI
         inputs = {

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -430,7 +430,7 @@ def runScript():
                 fmt_str = ", ".join(fp['format']) if fp['format'] else "any"
                 fp_param = omscripts.Long(
                     f"{wf}_|_FILE_{k}",
-                    optional=fp['optional'],
+                    optional=True,  # always optional: required-ness is enforced per chosen workflow at runtime
                     grouping=f"{parameter_group}.{num_reg + fp_incr + 1}",
                     description=(
                         f"[{fp['type'].capitalize()} attachment] {fp['description']}"
@@ -834,43 +834,62 @@ def run_workflow(slurmClient: SlurmClient,
         else:
             ft_script_id, ft_script_name = ft_matches[0]
             for param_id, fp in file_params.items():
-                ann_id = unwrap(client.getInput(f"{name}_|_FILE_{param_id}"))
-                if ann_id is None:
+                raw = unwrap(client.getInput(f"{name}_|_FILE_{param_id}"))
+                # Normalise: single int or list of ints → always a list
+                if raw is None:
+                    ann_ids = []
+                elif isinstance(raw, (list, tuple)):
+                    ann_ids = [int(v) for v in raw if v is not None]
+                else:
+                    ann_ids = [int(raw)]
+
+                if not ann_ids:
                     if not fp['optional']:
                         err = f"Required file attachment '{param_id}' has no annotation ID — cannot run workflow."
                         logger.error(err)
                         raise ValueError(err)
                     logger.debug(f"No annotation ID supplied for optional param '{param_id}', skipping.")
                     continue
-                logger.info(f"Transferring file attachment {ann_id} for param '{param_id}'")
-                ft_inputs = {
-                    constants.file_transfer.FILE_ANNOTATION_ID: rlong(ann_id),
-                    constants.file_transfer.FOLDER: rstring(zipfile),
-                    constants.CLEANUP: client.getInput(constants.CLEANUP) or rbool(True),
-                }
-                try:
-                    ft_task_id = slurmClient.workflowTracker.add_task_to_workflow(
-                        wf_id, ft_script_name, VERSION,
-                        ann_id, {k: unwrap(v) for k, v in ft_inputs.items()}
-                    )
-                    slurmClient.workflowTracker.start_task(ft_task_id)
-                except Exception as db_e:
-                    logger.error(f"DB error adding file-transfer task: {db_e}")
-                    raise
-                ft_rv, _ = runOMEROScript(client, svc, ft_script_id, ft_inputs,
-                                           slurmClient=slurmClient)
-                slurm_path = unwrap(ft_rv.get('Slurm_Path')) if ft_rv else None
-                ft_msg = unwrap(ft_rv.get('Message', None)) if ft_rv else ''
-                if slurm_path:
-                    kwargs[param_id] = slurm_path
-                    UI_messages += f"Transferred {fp['type']} '{param_id}' to {slurm_path}. "
-                    slurmClient.workflowTracker.complete_task(ft_task_id, ft_msg or slurm_path)
-                else:
-                    err = f"File transfer for '{param_id}' (ann {ann_id}) returned no path: {ft_msg}"
-                    logger.warning(err)
-                    slurmClient.workflowTracker.fail_task(ft_task_id, err)
-                    if not fp.get('optional', True):
-                        raise ValueError(err)
+
+                collected_paths = []
+                for ann_id in ann_ids:
+                    logger.info(f"Transferring file attachment {ann_id} for param '{param_id}'")
+                    ft_inputs = {
+                        constants.file_transfer.FILE_ANNOTATION_ID: rlong(ann_id),
+                        constants.file_transfer.FOLDER: rstring(zipfile),
+                        constants.CLEANUP: client.getInput(constants.CLEANUP) or rbool(True),
+                    }
+                    if fp.get('format'):
+                        ft_inputs[constants.file_transfer.FORMAT] = rstring(
+                            ",".join(fp['format'])
+                        )
+                    try:
+                        ft_task_id = slurmClient.workflowTracker.add_task_to_workflow(
+                            wf_id, ft_script_name, VERSION,
+                            ann_id, {k: unwrap(v) for k, v in ft_inputs.items()}
+                        )
+                        slurmClient.workflowTracker.start_task(ft_task_id)
+                    except Exception as db_e:
+                        logger.error(f"DB error adding file-transfer task: {db_e}")
+                        raise
+                    ft_rv, _ = runOMEROScript(client, svc, ft_script_id, ft_inputs,
+                                               slurmClient=slurmClient)
+                    slurm_path = unwrap(ft_rv.get('Slurm_Path')) if ft_rv else None
+                    ft_msg = unwrap(ft_rv.get('Message', None)) if ft_rv else ''
+                    if slurm_path:
+                        collected_paths.append(slurm_path)
+                        UI_messages += f"Transferred {fp['type']} '{param_id}' to {slurm_path}. "
+                        slurmClient.workflowTracker.complete_task(ft_task_id, ft_msg or slurm_path)
+                    else:
+                        err = f"File transfer for '{param_id}' (ann {ann_id}) returned no path: {ft_msg}"
+                        logger.warning(err)
+                        slurmClient.workflowTracker.fail_task(ft_task_id, err)
+                        if not fp.get('optional', True):
+                            raise ValueError(err)
+
+                if collected_paths:
+                    # Space-separated when multiple files; single value otherwise
+                    kwargs[param_id] = " ".join(collected_paths)
 
     logger.debug(f"Workflow parameters (incl. file paths): {kwargs}")
     try:

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -1523,9 +1523,21 @@ def importResultsToOmero(client: omscripts.client,
     inputs[constants.results.IMPORT_ONLY_LABELS] = rbool(True)
     inputs[constants.results.TEST_WRITE_PERMISSIONS_ONLY] = rbool(False)
 
-    # Forward file-output annotation flag
-    inputs[constants.results.OUTPUT_ATTACH_FILE_OUTPUTS] = rbool(
-        selected_output.get(constants.workflow.OUTPUT_ATTACH_FILE_OUTPUTS, False))
+    # Forward file-output annotation flag + destinations (mirrors CSV table wiring exactly)
+    if selected_output.get(constants.workflow.OUTPUT_ATTACH_FILE_OUTPUTS, False):
+        inputs[constants.results.OUTPUT_ATTACH_FILE_OUTPUTS] = rbool(True)
+        if parent_data_type == constants.transfer.DATA_TYPE_DATASET:
+            inputs[constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_DATASET] = rbool(True)
+            inputs[constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_DATASET_ID] = rlist(get_dataset_name_ids(conn, parent_id))
+        else:
+            inputs[constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_DATASET] = rbool(False)
+        if parent_data_type == constants.transfer.DATA_TYPE_PLATE:
+            inputs[constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_PLATE] = rbool(True)
+            inputs[constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_PLATE_ID] = rlist(get_plate_name_ids(conn, parent_id))
+        else:
+            inputs[constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_PLATE] = rbool(False)
+    else:
+        inputs[constants.results.OUTPUT_ATTACH_FILE_OUTPUTS] = rbool(False)
 
     # Wait for Slurm Accounting to update
     wait_for_job_completion(slurmClient, slurm_job_id)

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -1648,8 +1648,7 @@ def createFileName(client: omscripts.client, conn: BlitzGateway,
                    wf_id: UUID) -> str:
     """Generate a unique filename for workflow data transfer.
 
-    Creates a descriptive filename based on selected OMERO objects (images,
-    datasets, or plates) combined with the workflow UUID for uniqueness.
+    Creates a compact folder name with a BIOMERO prefix and workflow UUID.
 
     Args:
         client: OMERO script client for parameter access.
@@ -1657,37 +1656,10 @@ def createFileName(client: omscripts.client, conn: BlitzGateway,
         wf_id: Workflow UUID for filename uniqueness.
 
     Returns:
-        str: Generated filename incorporating object names and workflow ID.
+        str: Generated filename in the form ``biomero_<uuid>``.
 
-    Raises:
-        ValueError: If unsupported data type is provided.
     """
-    opts = {}
-    data_type = unwrap(client.getInput(constants.transfer.DATA_TYPE))
-    if data_type == constants.transfer.DATA_TYPE_IMAGE:
-        # get parent dataset
-        opts['image'] = unwrap(client.getInput(constants.transfer.IDS))[0]
-        objparams = ['%d_%s' % (d.id, d.getName())
-                     for d in conn.getObjects(
-                         constants.transfer.DATA_TYPE_DATASET, opts=opts)]
-    elif data_type == constants.transfer.DATA_TYPE_DATASET:
-        objparams = ['%d_%s' % (d.id, d.getName())
-                     for d in conn.getObjects(
-                         constants.transfer.DATA_TYPE_DATASET,
-                         unwrap(client.getInput(constants.transfer.IDS)))]
-    elif data_type == constants.transfer.DATA_TYPE_PLATE:
-        objparams = ['%d_%s' % (d.id, d.getName())
-                     for d in conn.getObjects(
-                         constants.transfer.DATA_TYPE_PLATE,
-                         unwrap(client.getInput(constants.transfer.IDS)))]
-    else:
-        raise ValueError(f"Can't handle {data_type}")
-
-    # timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-    filename = "_".join(objparams)
-    # Replace spaces with underscores in the filename
-    filename = filename.replace(" ", "_")
-    full_filename = f"{filename}_{wf_id}"
+    full_filename = f"biomero_{wf_id}"
     logger.debug("Filename: " + full_filename)
     return full_filename
 

--- a/__workflows/SLURM_Run_Workflow.py
+++ b/__workflows/SLURM_Run_Workflow.py
@@ -382,7 +382,7 @@ def runScript():
             # Get the workflow parameters (dynamically) from their repository
             _workflow_params[wf] = slurmClient.get_workflow_parameters(
                 wf)
-            json_descriptor = slurmClient.pull_descriptor_from_github(wf)
+            json_descriptor = slurmClient.generic_descriptor_from_github(wf)
             wf_descr = json_descriptor['description']
             # Build value-choices lookup from the descriptor (scoped per wf,
             # so param name collisions across workflows are not an issue)

--- a/__workflows/SLURM_Run_Workflow_Batched.py
+++ b/__workflows/SLURM_Run_Workflow_Batched.py
@@ -68,7 +68,8 @@ OUTPUT_OPTIONS = [constants.workflow.OUTPUT_RENAME,
                   constants.workflow.OUTPUT_NEW_DATASET,
                   constants.workflow.OUTPUT_NEW_SCREEN,
                   constants.workflow.OUTPUT_ATTACH,
-                  constants.workflow.OUTPUT_CSV_TABLE]
+                  constants.workflow.OUTPUT_CSV_TABLE,
+                  constants.workflow.OUTPUT_ATTACH_FILE_OUTPUTS]
 
 # Version constant for easy version management
 VERSION = "2.7.0"
@@ -207,7 +208,12 @@ def runScript():
                            optional=False,
                            grouping="02.8",
                            description="Any resulting csv files will be added as OMERO.table to parent dataset/plate",
-                           default=True)
+                           default=True),
+            omscripts.Bool(constants.workflow.OUTPUT_ATTACH_FILE_OUTPUTS,
+                           optional=True,
+                           grouping="02.85",
+                           description="Attach individual non-image output files (arrays, model weights, configs) as OMERO file annotations. Useful for bilayers workflows with 'array', 'file', or 'executable' output types.",
+                           default=False)
         ]
         # Generate script parameters for all our workflows
         (wf_versions, _) = slurmClient.get_all_image_versions_and_data_files()

--- a/__workflows/SLURM_Run_Workflow_Batched.py
+++ b/__workflows/SLURM_Run_Workflow_Batched.py
@@ -229,7 +229,7 @@ def runScript():
             _workflow_params[wf] = slurmClient.get_workflow_parameters(
                 wf)
             # Main parameter to select this workflow for execution
-            json_descriptor = slurmClient.pull_descriptor_from_github(wf)
+            json_descriptor = slurmClient.generic_descriptor_from_github(wf)
             wf_descr = json_descriptor['description']
             # Build value-choices lookup from the descriptor (scoped per wf,
             # so param name collisions across workflows are not an issue)

--- a/__workflows/SLURM_Run_Workflow_Batched.py
+++ b/__workflows/SLURM_Run_Workflow_Batched.py
@@ -269,21 +269,21 @@ def runScript():
                 # them to BIOMERO (as the wf will not understand these params)
                 omtype_param._name = f"{wf}_|_{omtype_param._name}"
                 input_list.append(omtype_param)
-            # File-attachment params: exposed as Long (OMERO FileAnnotation ID)
+            # File-attachment params: exposed as List(Long) of OMERO FileAnnotation IDs
             # They live under a FILE_ prefix so SLURM_Run_Workflow can tell them apart.
             num_reg = len(_workflow_params[wf])
             for fp_incr, (k, fp) in enumerate(_workflow_file_params[wf].items()):
                 fmt_str = ", ".join(fp['format']) if fp['format'] else "any"
-                fp_param = omscripts.Long(
+                fp_param = omscripts.List(
                     f"{wf}_|_FILE_{k}",
-                    optional=True,  # always optional: required-ness is enforced per chosen workflow at runtime
+                    optional=True,
                     grouping=f"{parameter_group}.{num_reg + fp_incr + 1}",
                     description=(
                         f"[{fp['type'].capitalize()} attachment] {fp['description']}"
                         f" Accepted formats: {fmt_str}."
-                        f" Provide the OMERO FileAnnotation ID."
+                        f" Provide one or more OMERO FileAnnotation IDs."
                     ),
-                )
+                ).ofType(rlong(0))
                 input_list.append(fp_param)
         # Finish setting up the Omero script UI
         inputs = {

--- a/__workflows/SLURM_Run_Workflow_Batched.py
+++ b/__workflows/SLURM_Run_Workflow_Batched.py
@@ -251,8 +251,17 @@ def runScript():
             # Create a script parameter for all workflow parameters
             for param_incr, (k, param) in enumerate(_workflow_params[
                     wf].items()):
-                # Convert the parameter from cy(tomine)type to om(ero)type
-                omtype_param = param
+                # Convert the parameter type to om(ero)type
+                omtype_param = slurmClient.convert_param_type_to_omtype(
+                    param["type"],
+                    param["default-value"],
+                    param["name"],
+                    description=param["description"],
+                    default=param["default-value"],
+                    grouping=f"{parameter_group}.{param_incr+1}",
+                    optional=param['optional'],
+                    **({"values": value_choices_map[k]} if k in value_choices_map else {})
+                )
                 # To allow 'duplicate' params, add the wf to uniqueify them
                 # we have to remove this prefix later again, before passing
                 # them to BIOMERO (as the wf will not understand these params)

--- a/__workflows/SLURM_Run_Workflow_Batched.py
+++ b/__workflows/SLURM_Run_Workflow_Batched.py
@@ -254,10 +254,10 @@ def runScript():
                 # Convert the parameter type to om(ero)type
                 omtype_param = slurmClient.convert_param_type_to_omtype(
                     param["type"],
-                    param["default-value"],
+                    param["default"],
                     param["name"],
                     description=param["description"],
-                    default=param["default-value"],
+                    default=param["default"],
                     grouping=f"{parameter_group}.{param_incr+1}",
                     optional=param['optional'],
                     **({"values": value_choices_map[k]} if k in value_choices_map else {})

--- a/__workflows/SLURM_Run_Workflow_Batched.py
+++ b/__workflows/SLURM_Run_Workflow_Batched.py
@@ -276,7 +276,7 @@ def runScript():
                 fmt_str = ", ".join(fp['format']) if fp['format'] else "any"
                 fp_param = omscripts.Long(
                     f"{wf}_|_FILE_{k}",
-                    optional=fp['optional'],
+                    optional=True,  # always optional: required-ness is enforced per chosen workflow at runtime
                     grouping=f"{parameter_group}.{num_reg + fp_incr + 1}",
                     description=(
                         f"[{fp['type'].capitalize()} attachment] {fp['description']}"

--- a/__workflows/SLURM_Run_Workflow_Batched.py
+++ b/__workflows/SLURM_Run_Workflow_Batched.py
@@ -252,16 +252,7 @@ def runScript():
             for param_incr, (k, param) in enumerate(_workflow_params[
                     wf].items()):
                 # Convert the parameter from cy(tomine)type to om(ero)type
-                omtype_param = slurmClient.convert_cytype_to_omtype(
-                    param["cytype"],
-                    param["default"],
-                    param["name"],
-                    description=param["description"],
-                    default=param["default"],
-                    grouping=f"{parameter_group}.{param_incr+1}",
-                    optional=param['optional'],
-                    **({"values": value_choices_map[k]} if k in value_choices_map else {})
-                )
+                omtype_param = param
                 # To allow 'duplicate' params, add the wf to uniqueify them
                 # we have to remove this prefix later again, before passing
                 # them to BIOMERO (as the wf will not understand these params)

--- a/__workflows/SLURM_Run_Workflow_Batched.py
+++ b/__workflows/SLURM_Run_Workflow_Batched.py
@@ -229,13 +229,13 @@ def runScript():
             _workflow_params[wf] = slurmClient.get_workflow_parameters(
                 wf)
             # Main parameter to select this workflow for execution
-            json_descriptor = slurmClient.generic_descriptor_from_github(wf)
-            wf_descr = json_descriptor['description']
+            descriptor = slurmClient.generic_descriptor_from_github(wf)
+            wf_descr = descriptor['description']
             # Build value-choices lookup from the descriptor (scoped per wf,
             # so param name collisions across workflows are not an issue)
             value_choices_map = {
                 inp['id']: [rstring(v) for v in inp['value-choices']]
-                for inp in json_descriptor.get('inputs', [])
+                for inp in descriptor.get('inputs', [])
                 if inp.get('value-choices')
             }
             wf_ = omscripts.Bool(wf, grouping=parameter_group, default=False,

--- a/__workflows/SLURM_Run_Workflow_Batched.py
+++ b/__workflows/SLURM_Run_Workflow_Batched.py
@@ -71,7 +71,7 @@ OUTPUT_OPTIONS = [constants.workflow.OUTPUT_RENAME,
                   constants.workflow.OUTPUT_CSV_TABLE]
 
 # Version constant for easy version management
-VERSION = "2.6.0"
+VERSION = "2.7.0"
 
 
 def runScript():
@@ -213,6 +213,7 @@ def runScript():
         (wf_versions, _) = slurmClient.get_all_image_versions_and_data_files()
         na = ["Not Available!"]
         _workflow_params = {}
+        _workflow_file_params = {}
         _workflow_available_versions = {}
         # All currently configured workflows
         workflows = wf_versions.keys()
@@ -226,8 +227,9 @@ def runScript():
             _workflow_available_versions[wf] = wf_versions.get(
                 wf, na)
             # Get the workflow parameters (dynamically) from their repository
-            _workflow_params[wf] = slurmClient.get_workflow_parameters(
-                wf)
+            _all_wf_params = slurmClient.get_workflow_parameters(wf)
+            _workflow_params[wf] = {k: v for k, v in _all_wf_params.items() if not v['file_attachment']}
+            _workflow_file_params[wf] = {k: v for k, v in _all_wf_params.items() if v['file_attachment']}
             # Main parameter to select this workflow for execution
             descriptor = slurmClient.generic_descriptor_from_github(wf)
             wf_descr = descriptor['description']
@@ -267,6 +269,22 @@ def runScript():
                 # them to BIOMERO (as the wf will not understand these params)
                 omtype_param._name = f"{wf}_|_{omtype_param._name}"
                 input_list.append(omtype_param)
+            # File-attachment params: exposed as Long (OMERO FileAnnotation ID)
+            # They live under a FILE_ prefix so SLURM_Run_Workflow can tell them apart.
+            num_reg = len(_workflow_params[wf])
+            for fp_incr, (k, fp) in enumerate(_workflow_file_params[wf].items()):
+                fmt_str = ", ".join(fp['format']) if fp['format'] else "any"
+                fp_param = omscripts.Long(
+                    f"{wf}_|_FILE_{k}",
+                    optional=fp['optional'],
+                    grouping=f"{parameter_group}.{num_reg + fp_incr + 1}",
+                    description=(
+                        f"[{fp['type'].capitalize()} attachment] {fp['description']}"
+                        f" Accepted formats: {fmt_str}."
+                        f" Provide the OMERO FileAnnotation ID."
+                    ),
+                )
+                input_list.append(fp_param)
         # Finish setting up the Omero script UI
         inputs = {
             p._name: p for p in input_list

--- a/_data/SLURM_Get_Results.py
+++ b/_data/SLURM_Get_Results.py
@@ -75,7 +75,7 @@ import numpy as np
 from omero_metadata.populate import ParsingContext
 
 # Version constant for easy version management
-VERSION = "2.6.0"
+VERSION = "2.7.0"
 
 OBJECT_TYPES = (
     'Plate',

--- a/_data/SLURM_Get_Results.py
+++ b/_data/SLURM_Get_Results.py
@@ -1404,14 +1404,14 @@ def process_non_image_file_outputs(
         '.mvd2', '.afi', '.exp', '.ipw', '.raw',
         '.nrrd', '.nhdr', '.am', '.amiramesh',
         '.avi', '.mov', '.flv', '.swf',
-        '.csv', '.zip',
+        '.csv',
         # NOTE: .log is intentionally omitted — workflow-generated log files
         # (e.g. run.log) are attached as individual file annotations. The SLURM
         # job log lives in local_tmp_storage, not in the scanned folder, so
         # there is no risk of double-attachment in Get_Results.
     )
 
-    namespace = NSCREATED + "/SLURM/SLURM_FILE_OUTPUTS"
+    namespace = NSCREATED + "/SLURM/SLURM_GET_RESULTS"
     message = ""
     attached_count = 0
     skipped_count = 0
@@ -1443,7 +1443,7 @@ def process_non_image_file_outputs(
                 mimetype = "application/octet-stream"
 
             description = (
-                f"Non-image output from SLURM job {slurm_job_id}"
+                f"File output from SLURM job {slurm_job_id}"
                 + (f" (Workflow {wf_id})" if wf_id else "")
             )
 

--- a/_data/SLURM_Get_Results.py
+++ b/_data/SLURM_Get_Results.py
@@ -1359,6 +1359,110 @@ def upload_zip_to_omero(client, conn, message, slurm_job_id, projects, folder, w
     return message
 
 
+def process_non_image_file_outputs(
+    conn,
+    folder: str,
+    projects: list,
+    slurm_job_id: str,
+    metadata_files=None,
+    wf_id=None,
+) -> str:
+    """Attach individual non-image, non-CSV output files as OMERO file annotations.
+
+    Scans *folder* for files that are neither images nor CSV tables nor the bulk
+    zip archive nor SLURM job logs.  Each remaining file (e.g. NumPy arrays,
+    model weights, JSON/YAML configs) is uploaded as a
+    :class:`omero.model.FileAnnotation` and linked to every object in *projects*.
+
+    Args:
+        conn: Open OMERO BlitzGateway connection.
+        folder: Path to the extracted workflow output directory.
+        projects: List of OMERO projects/plates/datasets to link annotations to.
+        slurm_job_id: SLURM job ID used in annotation descriptions.
+        metadata_files: File paths already attached as metadata CSVs (skipped).
+        wf_id: Workflow UUID used in annotation descriptions.
+
+    Returns:
+        Status message describing what was attached.
+    """
+    import mimetypes
+
+    if not projects:
+        logger.warning("process_non_image_file_outputs: no OMERO objects provided; skipping")
+        return "\nNo OMERO objects available for file annotation."
+
+    skip_paths = set(metadata_files or [])
+    skip_extensions = (
+        '.tif', '.tiff', '.ome.tif', '.ome.tiff',
+        '.png', '.jpg', '.jpeg', '.gif', '.bmp',
+        '.lsm', '.czi', '.nd2', '.oib', '.oif', '.vsi', '.scn',
+        '.svs', '.ims', '.lif', '.pic', '.flex', '.zvi',
+        '.zarr', '.ome.zarr',
+        '.dm3', '.dm4', '.ser', '.img', '.hdr', '.sdt',
+        '.psd', '.fits', '.dcm', '.dicom',
+        '.stk', '.lei', '.mrc', '.rec', '.st',
+        '.mvd2', '.afi', '.exp', '.ipw', '.raw',
+        '.nrrd', '.nhdr', '.am', '.amiramesh',
+        '.avi', '.mov', '.flv', '.swf',
+        '.csv', '.zip', '.log',
+    )
+
+    namespace = NSCREATED + "/SLURM/SLURM_FILE_OUTPUTS"
+    message = ""
+    attached_count = 0
+    skipped_count = 0
+
+    for dirpath, _dirnames, filenames in os.walk(folder):
+        for fname in filenames:
+            file_path = os.path.join(dirpath, fname)
+
+            if file_path in skip_paths:
+                skipped_count += 1
+                continue
+
+            lower = fname.lower()
+            if any(lower.endswith(ext) for ext in skip_extensions):
+                skipped_count += 1
+                continue
+
+            if fname.startswith('.'):
+                skipped_count += 1
+                continue
+
+            mimetype, _ = mimetypes.guess_type(file_path)
+            if mimetype is None:
+                mimetype = "application/octet-stream"
+
+            description = (
+                f"Non-image output from SLURM job {slurm_job_id}"
+                + (f" (Workflow {wf_id})" if wf_id else "")
+            )
+
+            try:
+                file_ann = conn.createFileAnnfromLocalFile(
+                    file_path, mimetype=mimetype,
+                    ns=namespace, desc=description)
+                logger.info(f"Created file annotation for {file_path} (id={file_ann.getId()})")
+            except Exception as e:
+                logger.error(f"Failed to create file annotation for {file_path}: {e}")
+                message += f"\nFailed to annotate {fname}: {e}"
+                continue
+
+            for obj in projects:
+                try:
+                    obj.linkAnnotation(file_ann)
+                    logger.debug(f"Linked {fname} annotation to {type(obj).__name__} {obj.getId()}")
+                except Exception as e:
+                    logger.error(f"Failed to link annotation for {file_path} to {obj}: {e}")
+                    message += f"\nFailed to link {fname} to {type(obj).__name__} {obj.getId()}: {e}"
+
+            attached_count += 1
+
+    summary = f"\nAttached {attached_count} non-image output file(s) as annotations (skipped {skipped_count} already-handled files)."
+    logger.info(summary)
+    return message + summary
+
+
 def extract_data_location_from_log(export_file):
     """Read SLURM job logfile to find location of the data
 
@@ -1568,7 +1672,7 @@ def runScript():
             scripts.Bool(constants.results.OUTPUT_ATTACH_PROJECT,
                          optional=False,
                          grouping="03",
-                         description="Attach all results in zip to a project",
+                         description="Attach a bulk zip archive of all results to a project (backup/download-all). Use the individual file annotations option to access specific output files without downloading the full archive.",
                          default=True),
             scripts.List(constants.results.OUTPUT_ATTACH_PROJECT_ID,
                          optional=True, grouping="03.1",
@@ -1577,7 +1681,7 @@ def runScript():
             scripts.Bool(constants.results.OUTPUT_ATTACH_DATASET,
                          optional=False,
                          grouping="04",
-                         description="Attach all results in zip to a dataset (used when dataset has no parent project)",
+                         description="Attach a bulk zip archive of all results to a dataset (used when dataset has no parent project). Use the individual file annotations option to access specific output files without downloading the full archive.",
                          default=False),
             scripts.List(constants.results.OUTPUT_ATTACH_DATASET_ID,
                          optional=True, grouping="04.1",
@@ -1586,7 +1690,7 @@ def runScript():
             scripts.Bool(constants.results.OUTPUT_ATTACH_PLATE,
                          optional=False,
                          grouping="05",
-                         description="Attach all results in zip to a plate",
+                         description="Attach a bulk zip archive of all results to a plate. Use the individual file annotations option to access specific output files without downloading the full archive.",,
                          default=False),
             scripts.List(constants.results.OUTPUT_ATTACH_PLATE_ID,
                          optional=True, grouping="05.1",
@@ -1651,9 +1755,14 @@ def runScript():
                          grouping="07.4",
                          description="Plate to attach workflow results to",
                          values=_plates),
-            scripts.Bool("Cleanup?",
+            scripts.Bool(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS,
                          optional=True,
                          grouping="08",
+                         description="Attach individual non-image output files (e.g. NumPy arrays, model weights, JSON/YAML configs) as OMERO file annotations. Bilayers workflows with 'array', 'file', or 'executable' output types benefit most from this option. Images and CSVs are handled separately.",
+                         default=False),
+            scripts.Bool("Cleanup?",
+                         optional=True,
+                         grouping="09",
                          description="Cleanup temporary files after completion (default: True). Turn off for debugging.",
                          default=True),
 
@@ -1864,6 +1973,13 @@ def runScript():
                             message = upload_contents_to_omero(
                                 client, conn, slurmClient, message, folder, metadata_files,
                                 wf_id=wf_id, input_images=input_images)
+
+                            # NON-IMAGE FILE OUTPUT ANNOTATIONS (bilayers array/file/executable outputs)
+                            if unwrap(client.getInput(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS)):
+                                file_outputs_message = process_non_image_file_outputs(
+                                    conn, folder, projects, slurm_job_id,
+                                    metadata_files=metadata_files, wf_id=wf_id)
+                                message += file_outputs_message
 
                             # Only cleanup if Cleanup? is True
                             if unwrap(client.getInput("Cleanup?")):

--- a/_data/SLURM_Get_Results.py
+++ b/_data/SLURM_Get_Results.py
@@ -1760,6 +1760,26 @@ def runScript():
                          grouping="08",
                          description="Attach individual non-image output files (e.g. NumPy arrays, model weights, JSON/YAML configs) as OMERO file annotations. Bilayers workflows with 'array', 'file', or 'executable' output types benefit most from this option. Images and CSVs are handled separately.",
                          default=False),
+            scripts.Bool(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_DATASET,
+                         optional=True,
+                         grouping="08.1",
+                         description="Attach to the dataset chosen below",
+                         default=True),
+            scripts.List(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_DATASET_ID,
+                         optional=True,
+                         grouping="08.2",
+                         description="Dataset to attach non-image file outputs to",
+                         values=_datasets),
+            scripts.Bool(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_PLATE,
+                         optional=True,
+                         grouping="08.3",
+                         description="Attach to the plate chosen below",
+                         default=False),
+            scripts.List(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_PLATE_ID,
+                         optional=True,
+                         grouping="08.4",
+                         description="Plate to attach non-image file outputs to",
+                         values=_plates),
             scripts.Bool("Cleanup?",
                          optional=True,
                          grouping="09",
@@ -1976,8 +1996,18 @@ def runScript():
 
                             # NON-IMAGE FILE OUTPUT ANNOTATIONS (bilayers array/file/executable outputs)
                             if unwrap(client.getInput(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS)):
+                                file_output_targets = []
+                                if unwrap(client.getInput(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_DATASET)):
+                                    dataset_ids = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_DATASET_ID))
+                                    if dataset_ids:
+                                        file_output_targets += [conn.getObject("Dataset", d.split(":")[0]) for d in dataset_ids]
+                                if unwrap(client.getInput(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_PLATE)):
+                                    plate_ids = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_PLATE_ID))
+                                    if plate_ids:
+                                        file_output_targets += [conn.getObject("Plate", p.split(":")[0]) for p in plate_ids]
+                                file_output_targets = [t for t in file_output_targets if t is not None]
                                 file_outputs_message = process_non_image_file_outputs(
-                                    conn, folder, projects, slurm_job_id,
+                                    conn, folder, file_output_targets, slurm_job_id,
                                     metadata_files=metadata_files, wf_id=wf_id)
                                 message += file_outputs_message
 

--- a/_data/SLURM_Get_Results.py
+++ b/_data/SLURM_Get_Results.py
@@ -1412,7 +1412,12 @@ def process_non_image_file_outputs(
     attached_count = 0
     skipped_count = 0
 
-    for dirpath, _dirnames, filenames in os.walk(folder):
+    for dirpath, dirnames, filenames in os.walk(folder):
+        # Prune zarr store directories — chunk files inside have no extension and
+        # would otherwise be picked up as file annotations. Zarr outputs are
+        # image-type outputs handled by the importer, not this function.
+        dirnames[:] = [d for d in dirnames
+                       if not d.lower().endswith(('.zarr', '.ome.zarr'))]
         for fname in filenames:
             file_path = os.path.join(dirpath, fname)
 

--- a/_data/SLURM_Get_Results.py
+++ b/_data/SLURM_Get_Results.py
@@ -1404,7 +1404,11 @@ def process_non_image_file_outputs(
         '.mvd2', '.afi', '.exp', '.ipw', '.raw',
         '.nrrd', '.nhdr', '.am', '.amiramesh',
         '.avi', '.mov', '.flv', '.swf',
-        '.csv', '.zip', '.log',
+        '.csv', '.zip',
+        # NOTE: .log is intentionally omitted — workflow-generated log files
+        # (e.g. run.log) are attached as individual file annotations. The SLURM
+        # job log lives in local_tmp_storage, not in the scanned folder, so
+        # there is no risk of double-attachment in Get_Results.
     )
 
     namespace = NSCREATED + "/SLURM/SLURM_FILE_OUTPUTS"

--- a/_data/SLURM_Get_Results.py
+++ b/_data/SLURM_Get_Results.py
@@ -1690,7 +1690,7 @@ def runScript():
             scripts.Bool(constants.results.OUTPUT_ATTACH_PLATE,
                          optional=False,
                          grouping="05",
-                         description="Attach a bulk zip archive of all results to a plate. Use the individual file annotations option to access specific output files without downloading the full archive.",,
+                         description="Attach a bulk zip archive of all results to a plate. Use the individual file annotations option to access specific output files without downloading the full archive.",
                          default=False),
             scripts.List(constants.results.OUTPUT_ATTACH_PLATE_ID,
                          optional=True, grouping="05.1",

--- a/_data/SLURM_Get_Update.py
+++ b/_data/SLURM_Get_Update.py
@@ -54,7 +54,7 @@ import os
 import sys
 
 # Version constant for easy version management
-VERSION = "2.6.0"
+VERSION = "2.7.0"
 
 logger = logging.getLogger(__name__)
 

--- a/_data/SLURM_Import_Results.py
+++ b/_data/SLURM_Import_Results.py
@@ -3074,10 +3074,14 @@ def process_non_image_file_outputs(
     # Build set of paths to skip (already handled by other processors)
     skip_paths: set = set(metadata_files or [])
 
-    # Extensions that are handled by other processors
+    # Extensions that are handled by other processors.
+    # NOTE: .log is intentionally NOT in this list — workflow-generated log files
+    # (e.g. run.log) are attached as file annotations just like any other output.
+    # The SLURM job log (omero-{job_id}.log) is excluded via skip_paths at the
+    # call site, since upload_log_to_omero already handled it.
     skip_extensions = (
         tuple(SUPPORTED_IMAGE_EXTENSIONS)
-        + ('.csv', '.zip', '.log')
+        + ('.csv', '.zip')
     )
 
     namespace = NSCREATED + "/SLURM/SLURM_FILE_OUTPUTS"
@@ -4024,9 +4028,15 @@ def runScript() -> None:
                     if plate_ids:
                         file_output_targets += [conn.getObject("Plate", p.split(":")[0]) for p in plate_ids]
                 file_output_targets = [t for t in file_output_targets if t is not None]
+                # Exclude the SLURM job log from file-annotation attachment —
+                # upload_log_to_omero already attached it. All other .log files
+                # (e.g. workflow run.log) are processed normally.
+                _file_skip = list(metadata_files or [])
+                if log_to_upload:
+                    _file_skip.append(log_to_upload)
                 file_outputs_message = process_non_image_file_outputs(
                     conn, permanent_storage_path, file_output_targets,
-                    slurm_job_id, metadata_files=metadata_files, wf_id=wf_id)
+                    slurm_job_id, metadata_files=_file_skip, wf_id=wf_id)
                 message += file_outputs_message
 
             logger.info("Results imported successfully")

--- a/_data/SLURM_Import_Results.py
+++ b/_data/SLURM_Import_Results.py
@@ -3033,6 +3033,114 @@ def process_zip_attachments(
     return message
 
 
+def process_non_image_file_outputs(
+    conn: BlitzGateway,
+    permanent_storage_path: str,
+    projects: List[Any],
+    slurm_job_id: str,
+    metadata_files: Optional[List[str]] = None,
+    wf_id: Optional[str] = None,
+) -> str:
+    """Attach individual non-image, non-CSV output files as OMERO file annotations.
+
+    Scans *permanent_storage_path* for files that are neither images (handled
+    by the importer), nor CSV tables (handled by process_slurm_tables), nor the
+    bulk zip archive, nor SLURM job logs.  Every remaining file — e.g. NumPy
+    arrays (.npy/.npz), model weights (.pt/.h5/.pkl), JSON/YAML configs — is
+    registered as a :class:`omero.model.FileAnnotation` (in-place when the
+    importer is available) and linked to every object in *projects*.
+
+    This enables bilayers-style workflows that declare ``array``, ``file``, or
+    ``executable`` output types to surface those artefacts directly in OMERO
+    without relying solely on the bulk zip.
+
+    Args:
+        conn: Open OMERO BlitzGateway connection.
+        permanent_storage_path: Path to the permanent workflow storage directory
+            (the ``.analyzed/{uuid}/{timestamp}`` directory).
+        projects: List of OMERO projects/plates/datasets to link annotations to.
+        slurm_job_id: SLURM job ID used in annotation descriptions.
+        metadata_files: File paths that were already attached as metadata CSVs
+            (skipped to avoid duplication). Defaults to None.
+        wf_id: Workflow UUID used in annotation descriptions. Defaults to None.
+
+    Returns:
+        Status message describing what was attached.
+    """
+    if not projects:
+        logger.warning("process_non_image_file_outputs: no OMERO objects provided; skipping")
+        return "\nNo OMERO objects available for file annotation."
+
+    # Build set of paths to skip (already handled by other processors)
+    skip_paths: set = set(metadata_files or [])
+
+    # Extensions that are handled by other processors
+    skip_extensions = (
+        tuple(SUPPORTED_IMAGE_EXTENSIONS)
+        + ('.csv', '.zip', '.log')
+    )
+
+    namespace = NSCREATED + "/SLURM/SLURM_FILE_OUTPUTS"
+    message = ""
+    attached_count = 0
+    skipped_count = 0
+
+    for dirpath, _dirnames, filenames in os.walk(permanent_storage_path):
+        for fname in filenames:
+            file_path = os.path.join(dirpath, fname)
+
+            # Skip already-handled paths
+            if file_path in skip_paths:
+                skipped_count += 1
+                continue
+
+            # Skip by extension
+            lower = fname.lower()
+            if any(lower.endswith(ext) for ext in skip_extensions):
+                skipped_count += 1
+                continue
+
+            # Skip hidden/system files
+            if fname.startswith('.'):
+                skipped_count += 1
+                continue
+
+            # Guess mimetype; fall back to application/octet-stream
+            import mimetypes
+            mimetype, _ = mimetypes.guess_type(file_path)
+            if mimetype is None:
+                mimetype = "application/octet-stream"
+
+            description = (
+                f"Non-image output from SLURM job {slurm_job_id}"
+                + (f" (Workflow {wf_id})" if wf_id else "")
+            )
+
+            try:
+                file_ann = create_file_annotation_inplace(
+                    conn, file_path, mimetype, namespace, description)
+                logger.info(f"Created file annotation for {file_path} (id={file_ann.getId()})")
+            except Exception as e:
+                logger.error(f"Failed to create file annotation for {file_path}: {e}")
+                message += f"\nFailed to annotate {fname}: {e}"
+                continue
+
+            # Link annotation to all target OMERO objects
+            for obj in projects:
+                try:
+                    obj.linkAnnotation(file_ann)
+                    logger.debug(f"Linked {fname} annotation to {type(obj).__name__} {obj.getId()}")
+                except Exception as e:
+                    logger.error(f"Failed to link annotation for {file_path} to {obj}: {e}")
+                    message += f"\nFailed to link {fname} to {type(obj).__name__} {obj.getId()}: {e}"
+
+            attached_count += 1
+
+    summary = f"\nAttached {attached_count} non-image output file(s) as annotations (skipped {skipped_count} already-handled files)."
+    logger.info(summary)
+    return message + summary
+
+
 def cleanup_resources(
     client: Any,
     slurmClient: SlurmClient,
@@ -3430,7 +3538,7 @@ def runScript() -> None:
             scripts.Bool(constants.results.OUTPUT_ATTACH_PROJECT,
                          optional=False,
                          grouping="02",
-                         description="Attach all results in zip to a project",
+                         description="Attach a bulk zip archive of all results to a project (backup/download-all). Use the individual file annotations option to access specific output files without downloading the full archive.",
                          default=False),
             scripts.List(constants.results.OUTPUT_ATTACH_PROJECT_ID,
                          optional=True, grouping="02.1",
@@ -3439,7 +3547,7 @@ def runScript() -> None:
             scripts.Bool(constants.results.OUTPUT_ATTACH_DATASET,
                          optional=False,
                          grouping="03",
-                         description="Attach all results in zip to a dataset (used when dataset has no parent project)",
+                         description="Attach a bulk zip archive of all results to a dataset (used when dataset has no parent project). Use the individual file annotations option to access specific output files without downloading the full archive.",
                          default=False),
             scripts.List(constants.results.OUTPUT_ATTACH_DATASET_ID,
                          optional=True, grouping="03.1",
@@ -3448,7 +3556,7 @@ def runScript() -> None:
             scripts.Bool(constants.results.OUTPUT_ATTACH_PLATE,
                          optional=False,
                          grouping="04",
-                         description="Attach all results in zip to a plate",
+                         description="Attach a bulk zip archive of all results to a plate. Use the individual file annotations option to access specific output files without downloading the full archive.",
                          default=False),
             scripts.List(constants.results.OUTPUT_ATTACH_PLATE_ID,
                          optional=True, grouping="04.1",
@@ -3542,14 +3650,19 @@ def runScript() -> None:
                          grouping="08.4",
                          description="Plate to attach workflow results to",
                          values=_plates),
-            scripts.Bool(constants.CLEANUP,
+            scripts.Bool(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS,
                          optional=True,
                          grouping="09",
+                         description="Attach individual non-image output files (e.g. NumPy arrays, model weights, JSON/YAML configs) as OMERO file annotations. Bilayers workflows with 'array', 'file', or 'executable' output types benefit most from this option. Images and CSVs are handled separately.",
+                         default=False),
+            scripts.Bool(constants.CLEANUP,
+                         optional=True,
+                         grouping="10",
                          description="Cleanup temporary files after completion (default: True). Turn off for debugging.",
                          default=True),
             scripts.Bool(constants.results.TEST_WRITE_PERMISSIONS_ONLY,
                          optional=True,
-                         grouping="09.1",
+                         grouping="10.1",
                          description="DRY-RUN ONLY: Test write permissions to importer storage and exit (no actual import). " + \
                                     "Use this to validate storage configuration before running expensive workflows.",
                          default=False),
@@ -3643,6 +3756,8 @@ def runScript() -> None:
                 constants.results.OUTPUT_ATTACH_NEW_SCREEN))
             process_csv_tables = unwrap(client.getInput(
                 constants.results.OUTPUT_ATTACH_TABLE))
+            process_file_outputs = unwrap(client.getInput(
+                constants.results.OUTPUT_ATTACH_FILE_OUTPUTS)) or False
             process_attachments = (unwrap(client.getInput(constants.results.OUTPUT_ATTACH_OG_IMAGES)) or
                                    unwrap(client.getInput(constants.results.OUTPUT_ATTACH_PROJECT)) or
                                    unwrap(client.getInput(constants.results.OUTPUT_ATTACH_DATASET)) or
@@ -3650,7 +3765,7 @@ def runScript() -> None:
 
             # Debug the workflow decisions
             logger.info(
-                f"Workflow decisions: use_importer_for_datasets={use_importer_for_datasets}, use_importer_for_screens={use_importer_for_screens}, process_csv_tables={process_csv_tables}, process_attachments={process_attachments}")
+                f"Workflow decisions: use_importer_for_datasets={use_importer_for_datasets}, use_importer_for_screens={use_importer_for_screens}, process_csv_tables={process_csv_tables}, process_attachments={process_attachments}, process_file_outputs={process_file_outputs}")
 
             # Initialize importer only if needed for dataset or screen imports
             importer_initialized = False
@@ -3872,6 +3987,13 @@ def runScript() -> None:
                     metadata_files, wf_id, input_images=input_images,
                     og_name_map=og_name_map)
                 message += attachment_message
+
+            # NON-IMAGE FILE OUTPUT ANNOTATIONS (bilayers array/file/executable outputs)
+            if process_file_outputs:
+                file_outputs_message = process_non_image_file_outputs(
+                    conn, permanent_storage_path, projects,
+                    slurm_job_id, metadata_files=metadata_files, wf_id=wf_id)
+                message += file_outputs_message
 
             logger.info("Results imported successfully")
             message += "\nWorkflow execution completed successfully."

--- a/_data/SLURM_Import_Results.py
+++ b/_data/SLURM_Import_Results.py
@@ -138,7 +138,7 @@ if not IMPORTER_ENABLED:
         "IMPORTER_ENABLED is false - dataset imports will not be supported")
 
 # Version constant for easy version management
-VERSION = "2.6.0"
+VERSION = "2.7.0"
 
 OBJECT_TYPES = (
     'Plate',

--- a/_data/SLURM_Import_Results.py
+++ b/_data/SLURM_Import_Results.py
@@ -3081,11 +3081,17 @@ def process_non_image_file_outputs(
     )
 
     namespace = NSCREATED + "/SLURM/SLURM_FILE_OUTPUTS"
+    import mimetypes
     message = ""
     attached_count = 0
     skipped_count = 0
 
-    for dirpath, _dirnames, filenames in os.walk(permanent_storage_path):
+    for dirpath, dirnames, filenames in os.walk(permanent_storage_path):
+        # Prune zarr store directories — chunk files inside have no extension and
+        # would otherwise be picked up as file annotations. Zarr outputs are
+        # image-type outputs handled by the importer, not this function.
+        dirnames[:] = [d for d in dirnames
+                       if not d.lower().endswith(('.zarr', '.ome.zarr'))]
         for fname in filenames:
             file_path = os.path.join(dirpath, fname)
 
@@ -3105,8 +3111,6 @@ def process_non_image_file_outputs(
                 skipped_count += 1
                 continue
 
-            # Guess mimetype; fall back to application/octet-stream
-            import mimetypes
             mimetype, _ = mimetypes.guess_type(file_path)
             if mimetype is None:
                 mimetype = "application/octet-stream"

--- a/_data/SLURM_Import_Results.py
+++ b/_data/SLURM_Import_Results.py
@@ -3655,6 +3655,26 @@ def runScript() -> None:
                          grouping="09",
                          description="Attach individual non-image output files (e.g. NumPy arrays, model weights, JSON/YAML configs) as OMERO file annotations. Bilayers workflows with 'array', 'file', or 'executable' output types benefit most from this option. Images and CSVs are handled separately.",
                          default=False),
+            scripts.Bool(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_DATASET,
+                         optional=True,
+                         grouping="09.1",
+                         description="Attach to the dataset chosen below",
+                         default=True),
+            scripts.List(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_DATASET_ID,
+                         optional=True,
+                         grouping="09.2",
+                         description="Dataset to attach non-image file outputs to",
+                         values=_datasets),
+            scripts.Bool(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_PLATE,
+                         optional=True,
+                         grouping="09.3",
+                         description="Attach to the plate chosen below",
+                         default=False),
+            scripts.List(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_PLATE_ID,
+                         optional=True,
+                         grouping="09.4",
+                         description="Plate to attach non-image file outputs to",
+                         values=_plates),
             scripts.Bool(constants.CLEANUP,
                          optional=True,
                          grouping="10",
@@ -3990,8 +4010,18 @@ def runScript() -> None:
 
             # NON-IMAGE FILE OUTPUT ANNOTATIONS (bilayers array/file/executable outputs)
             if process_file_outputs:
+                file_output_targets = []
+                if unwrap(client.getInput(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_DATASET)):
+                    dataset_ids = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_DATASET_ID))
+                    if dataset_ids:
+                        file_output_targets += [conn.getObject("Dataset", d.split(":")[0]) for d in dataset_ids]
+                if unwrap(client.getInput(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_PLATE)):
+                    plate_ids = unwrap(client.getInput(constants.results.OUTPUT_ATTACH_FILE_OUTPUTS_PLATE_ID))
+                    if plate_ids:
+                        file_output_targets += [conn.getObject("Plate", p.split(":")[0]) for p in plate_ids]
+                file_output_targets = [t for t in file_output_targets if t is not None]
                 file_outputs_message = process_non_image_file_outputs(
-                    conn, permanent_storage_path, projects,
+                    conn, permanent_storage_path, file_output_targets,
                     slurm_job_id, metadata_files=metadata_files, wf_id=wf_id)
                 message += file_outputs_message
 

--- a/_data/SLURM_Import_Results.py
+++ b/_data/SLURM_Import_Results.py
@@ -3081,10 +3081,10 @@ def process_non_image_file_outputs(
     # call site, since upload_log_to_omero already handled it.
     skip_extensions = (
         tuple(SUPPORTED_IMAGE_EXTENSIONS)
-        + ('.csv', '.zip')
+        + ('.csv',)
     )
 
-    namespace = NSCREATED + "/SLURM/SLURM_FILE_OUTPUTS"
+    namespace = NSCREATED + "/SLURM/SLURM_GET_RESULTS"
     import mimetypes
     message = ""
     attached_count = 0
@@ -3120,7 +3120,7 @@ def process_non_image_file_outputs(
                 mimetype = "application/octet-stream"
 
             description = (
-                f"Non-image output from SLURM job {slurm_job_id}"
+                f"File output from SLURM job {slurm_job_id}"
                 + (f" (Workflow {wf_id})" if wf_id else "")
             )
 
@@ -4031,9 +4031,15 @@ def runScript() -> None:
                 # Exclude the SLURM job log from file-annotation attachment —
                 # upload_log_to_omero already attached it. All other .log files
                 # (e.g. workflow run.log) are processed normally.
+                # Also exclude the bulk results zip ({job_id}_out.zip) — it is the
+                # full archive of all results and is handled by process_zip_attachments;
+                # workflow-produced zips inside subdirectories attach normally.
                 _file_skip = list(metadata_files or [])
                 if log_to_upload:
                     _file_skip.append(log_to_upload)
+                _bulk_zip = os.path.join(permanent_storage_path, f"{slurm_job_id}_out.zip")
+                if os.path.exists(_bulk_zip):
+                    _file_skip.append(_bulk_zip)
                 file_outputs_message = process_non_image_file_outputs(
                     conn, permanent_storage_path, file_output_targets,
                     slurm_job_id, metadata_files=_file_skip, wf_id=wf_id)

--- a/_data/SLURM_Remote_Conversion.py
+++ b/_data/SLURM_Remote_Conversion.py
@@ -49,7 +49,7 @@ CONV_OPTIONS_SOURCE = ['zarr']
 CONV_OPTIONS_TARGET = ['tiff', 'zarr']
 
 # Version constant for easy version management
-VERSION = "2.6.0"
+VERSION = "2.7.0"
 
 
 def runScript():

--- a/_data/_SLURM_File_Transfer.py
+++ b/_data/_SLURM_File_Transfer.py
@@ -53,7 +53,7 @@ import tempfile
 import omero.scripts as scripts
 import omero
 from omero.gateway import BlitzGateway
-from omero.rtypes import rstring, rlong
+from omero.rtypes import rstring
 
 from biomero import SlurmClient, constants
 
@@ -71,6 +71,7 @@ def transfer_file_to_slurm(
     annotation_id: int,
     folder_name: str,
     slurmClient: SlurmClient,
+    param_slot: str = None,
     cleanup: bool = True,
     allowed_formats: list = None,
 ) -> tuple[str, str]:
@@ -83,6 +84,9 @@ def transfer_file_to_slurm(
             folder name used for the image transfer so both end up in the
             same data/in/ directory. Created automatically if absent.
         slurmClient: Authenticated SlurmClient instance.
+        param_slot: Optional opaque routing slot. When provided, files are
+            placed in a dedicated subdirectory:
+            ``{Folder_Name}/data/in/{param_slot}/``.
         cleanup: If True, delete the local temp file after transfer.
         allowed_formats: Optional list of accepted file extensions (without
             leading dot, e.g. ["csv", "unix"]). If provided and the file's
@@ -146,7 +150,14 @@ def transfer_file_to_slurm(
         # ------------------------------------------------------------------
         # 3. Create destination directory on SLURM
         # ------------------------------------------------------------------
-        dest_dir = f"{slurmClient.slurm_data_path}/{folder_name}/data/in"
+        dest_root = f"{slurmClient.slurm_data_path}/{folder_name}/data/in"
+        if param_slot:
+            safe_param = str(param_slot).strip().replace(
+                "/", "_"
+            ).replace("\\", "_")
+            dest_dir = f"{dest_root}/{safe_param}"
+        else:
+            dest_dir = dest_root
         mkdir_result = slurmClient.run_commands(
             [f'mkdir -p "{dest_dir}"']
         )
@@ -212,8 +223,20 @@ Connection ready? {slurmClient.validate()}""",
                 description=(
                     "SLURM job data folder name (e.g. SLURM_IMAGES_1234567890). "
                     "Must match the folder name used for the image transfer so "
-                    "images and file attachments share the same data/in/ directory. "
-                    "The directory is created automatically if it does not yet exist."
+                    "images and file attachments share the same data/in/ "
+                    "directory. The directory is created automatically if it "
+                    "does not yet exist."
+                ),
+            ),
+
+            scripts.String(
+                constants.file_transfer.PARAM_SLOT,
+                optional=True,
+                grouping="2.1",
+                description=(
+                    "Optional opaque routing slot for subdirectory routing. "
+                    "When provided, file is transferred into "
+                    "{Folder_Name}/data/in/{Param_Slot}/."
                 ),
             ),
 
@@ -251,8 +274,11 @@ Connection ready? {slurmClient.validate()}""",
             conn = BlitzGateway(client_obj=client)
             script_params = client.getInputs(unwrap=True)
 
-            annotation_id = script_params[constants.file_transfer.FILE_ANNOTATION_ID]
+            annotation_id = script_params[
+                constants.file_transfer.FILE_ANNOTATION_ID
+            ]
             folder_name = script_params[constants.file_transfer.FOLDER]
+            param_slot = script_params.get(constants.file_transfer.PARAM_SLOT)
             cleanup = script_params.get(constants.CLEANUP, True)
             formats_raw = script_params.get(constants.file_transfer.FORMAT, "")
             allowed_formats = (
@@ -265,6 +291,7 @@ Connection ready? {slurmClient.validate()}""",
                 annotation_id=annotation_id,
                 folder_name=folder_name,
                 slurmClient=slurmClient,
+                param_slot=param_slot,
                 cleanup=cleanup,
                 allowed_formats=allowed_formats,
             )

--- a/_data/_SLURM_File_Transfer.py
+++ b/_data/_SLURM_File_Transfer.py
@@ -72,6 +72,7 @@ def transfer_file_to_slurm(
     folder_name: str,
     slurmClient: SlurmClient,
     cleanup: bool = True,
+    allowed_formats: list = None,
 ) -> tuple[str, str]:
     """Download an OMERO FileAnnotation and upload it to the SLURM cluster.
 
@@ -83,13 +84,18 @@ def transfer_file_to_slurm(
             same data/in/ directory. Created automatically if absent.
         slurmClient: Authenticated SlurmClient instance.
         cleanup: If True, delete the local temp file after transfer.
+        allowed_formats: Optional list of accepted file extensions (without
+            leading dot, e.g. ["csv", "unix"]). If provided and the file's
+            extension is not in the list, a ValueError is raised before any
+            data transfer takes place.
 
     Returns:
         (slurm_path, message): Absolute path of the file on SLURM and a
         human-readable status message.
 
     Raises:
-        ValueError: If the annotation or its underlying file cannot be found.
+        ValueError: If the annotation or its underlying file cannot be found,
+            or if the file extension does not match ``allowed_formats``.
         Exception: On SSH / SCP failure.
     """
     # ------------------------------------------------------------------
@@ -107,6 +113,20 @@ def transfer_file_to_slurm(
         )
     filename = orig_file.getName()
     file_size = orig_file.getSize()
+
+    # ------------------------------------------------------------------
+    # Validate file extension against allowed formats (if specified)
+    # ------------------------------------------------------------------
+    if allowed_formats:
+        ext = os.path.splitext(filename)[1].lstrip('.').lower()
+        normalised = [f.lstrip('.').lower() for f in allowed_formats if f]
+        if normalised and ext not in normalised:
+            raise ValueError(
+                f"File '{filename}' has extension '.{ext}' but this parameter "
+                f"expects one of: {normalised}. "
+                f"Please select a file with a supported format."
+            )
+
     logger.info(
         f"Downloading FileAnnotation {annotation_id} "
         f"('{filename}', {file_size} bytes) …"
@@ -207,6 +227,18 @@ Connection ready? {slurmClient.validate()}""",
                 default=True,
             ),
 
+            scripts.String(
+                constants.file_transfer.FORMAT,
+                optional=True,
+                grouping="4",
+                description=(
+                    "Comma-separated list of accepted file extensions "
+                    "(without leading dot, e.g. 'csv,parquet'). "
+                    "When provided, the transfer is rejected if the selected "
+                    "file does not match. Leave empty to skip validation."
+                ),
+            ),
+
             version=VERSION,
             authors=["Torec Luik"],
             institutions=["Amsterdam UMC"],
@@ -222,6 +254,11 @@ Connection ready? {slurmClient.validate()}""",
             annotation_id = script_params[constants.file_transfer.FILE_ANNOTATION_ID]
             folder_name = script_params[constants.file_transfer.FOLDER]
             cleanup = script_params.get(constants.CLEANUP, True)
+            formats_raw = script_params.get(constants.file_transfer.FORMAT, "")
+            allowed_formats = (
+                [f.strip() for f in formats_raw.split(",") if f.strip()]
+                if formats_raw else None
+            )
 
             slurm_path, message = transfer_file_to_slurm(
                 conn=conn,
@@ -229,6 +266,7 @@ Connection ready? {slurmClient.validate()}""",
                 folder_name=folder_name,
                 slurmClient=slurmClient,
                 cleanup=cleanup,
+                allowed_formats=allowed_formats,
             )
 
             client.setOutput("Message", rstring(message))

--- a/_data/_SLURM_File_Transfer.py
+++ b/_data/_SLURM_File_Transfer.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2024 T T Luik
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+BIOMERO SLURM File Attachment Transfer Script
+
+Transfers a single OMERO FileAnnotation to a SLURM cluster, placing it
+under the correct parameter input directory so the workflow container
+receives it as a CLI flag.
+
+The destination on SLURM is:
+  {slurm_data_path}/{Folder_Name}/data/in/{filename}
+
+The resolved absolute SLURM path is returned as the ``Slurm_Path`` output,
+which ``SLURM_Run_Workflow.py`` injects as the CLI argument value for the
+corresponding workflow parameter.
+
+Inputs:
+    Annotation_ID (Long): OMERO FileAnnotation ID supplied by the user.
+    Folder_Name (String): The job data folder on SLURM (same value used
+        when the images were transferred, e.g. ``SLURM_IMAGES_1234567890``).
+    Cleanup? (Bool, optional): Remove the local temp file after transfer
+        (default True).
+
+Outputs:
+    Slurm_Path (String): Absolute SLURM path of the transferred file.
+    Message (String): Human-readable status / error message.
+
+Authors: Torec Luik
+Institutions: Amsterdam UMC
+Contact: cellularimaging@amsterdamumc.nl
+"""
+
+import os
+import sys
+import logging
+import logging.handlers
+import tempfile
+
+import omero.scripts as scripts
+import omero
+from omero.gateway import BlitzGateway
+from omero.rtypes import rstring, rlong
+
+from biomero import SlurmClient, constants
+
+logger = logging.getLogger(__name__)
+
+VERSION = "2.7.0"
+
+
+# ---------------------------------------------------------------------------
+# Core transfer logic
+# ---------------------------------------------------------------------------
+
+def transfer_file_to_slurm(
+    conn: BlitzGateway,
+    annotation_id: int,
+    folder_name: str,
+    slurmClient: SlurmClient,
+    cleanup: bool = True,
+) -> tuple[str, str]:
+    """Download an OMERO FileAnnotation and upload it to the SLURM cluster.
+
+    Args:
+        conn: Active OMERO BlitzGateway connection.
+        annotation_id: ID of the OMERO FileAnnotation to transfer.
+        folder_name: Name of the job data folder on SLURM. Must match the
+            folder name used for the image transfer so both end up in the
+            same data/in/ directory. Created automatically if absent.
+        slurmClient: Authenticated SlurmClient instance.
+        cleanup: If True, delete the local temp file after transfer.
+
+    Returns:
+        (slurm_path, message): Absolute path of the file on SLURM and a
+        human-readable status message.
+
+    Raises:
+        ValueError: If the annotation or its underlying file cannot be found.
+        Exception: On SSH / SCP failure.
+    """
+    # ------------------------------------------------------------------
+    # 1. Fetch the FileAnnotation and its underlying OriginalFile
+    # ------------------------------------------------------------------
+    ann = conn.getObject("FileAnnotation", annotation_id)
+    if ann is None:
+        raise ValueError(
+            f"FileAnnotation {annotation_id} not found or not accessible."
+        )
+    orig_file = ann.getFile()
+    if orig_file is None:
+        raise ValueError(
+            f"FileAnnotation {annotation_id} has no associated OriginalFile."
+        )
+    filename = orig_file.getName()
+    file_size = orig_file.getSize()
+    logger.info(
+        f"Downloading FileAnnotation {annotation_id} "
+        f"('{filename}', {file_size} bytes) …"
+    )
+
+    # ------------------------------------------------------------------
+    # 2. Download file bytes to a local temp file
+    # ------------------------------------------------------------------
+    tmp_dir = tempfile.mkdtemp(prefix="biomero_ft_")
+    local_path = os.path.join(tmp_dir, filename)
+    try:
+        with open(local_path, "wb") as fh:
+            for chunk in ann.getFileInChunks():
+                fh.write(chunk)
+        logger.info(f"File saved locally to {local_path}")
+
+        # ------------------------------------------------------------------
+        # 3. Create destination directory on SLURM
+        # ------------------------------------------------------------------
+        dest_dir = f"{slurmClient.slurm_data_path}/{folder_name}/data/in"
+        mkdir_result = slurmClient.run_commands(
+            [f'mkdir -p "{dest_dir}"']
+        )
+        if not mkdir_result.ok:
+            raise Exception(
+                f"Failed to create remote directory '{dest_dir}': "
+                f"{mkdir_result.stderr}"
+            )
+        logger.info(f"Remote directory ready: {dest_dir}")
+
+        # ------------------------------------------------------------------
+        # 4. Transfer file to SLURM
+        # ------------------------------------------------------------------
+        slurmClient.put(local=local_path, remote=dest_dir)
+        slurm_path = f"{dest_dir}/{filename}"
+        logger.info(f"File transferred to SLURM: {slurm_path}")
+        message = (
+            f"Successfully transferred '{filename}' to SLURM "
+            f"into '{folder_name}/data/in/'."
+        )
+        return slurm_path, message
+
+    finally:
+        if cleanup and os.path.exists(local_path):
+            os.remove(local_path)
+            os.rmdir(tmp_dir)
+            logger.debug(f"Cleaned up local temp file {local_path}")
+
+
+# ---------------------------------------------------------------------------
+# OMERO script entry point
+# ---------------------------------------------------------------------------
+
+def run_script():
+    """OMERO script entry point for _SLURM_File_Transfer."""
+
+    with SlurmClient.from_config() as slurmClient:
+
+        client = scripts.client(
+            "_SLURM_File_Transfer",
+            f"""Transfer an OMERO FileAnnotation to the SLURM cluster.
+
+Places the file under:
+  {{slurm_data_path}}/{{Folder_Name}}/data/in/{{filename}}
+
+Returns the resolved SLURM path so SLURM_Run_Workflow can pass it as a
+CLI flag to the workflow container.
+
+This runs a script remotely on your SLURM cluster.
+Connection ready? {slurmClient.validate()}""",
+
+            scripts.Long(
+                constants.file_transfer.FILE_ANNOTATION_ID,
+                optional=False,
+                grouping="1",
+                description="OMERO FileAnnotation ID of the file to transfer.",
+            ),
+
+            scripts.String(
+                constants.file_transfer.FOLDER,
+                optional=False,
+                grouping="2",
+                description=(
+                    "SLURM job data folder name (e.g. SLURM_IMAGES_1234567890). "
+                    "Must match the folder name used for the image transfer so "
+                    "images and file attachments share the same data/in/ directory. "
+                    "The directory is created automatically if it does not yet exist."
+                ),
+            ),
+
+            scripts.Bool(
+                constants.CLEANUP,
+                grouping="3",
+                description=(
+                    "Remove the local temporary file after transfer. "
+                    "Uncheck for debugging."
+                ),
+                default=True,
+            ),
+
+            version=VERSION,
+            authors=["Torec Luik"],
+            institutions=["Amsterdam UMC"],
+            contact="cellularimaging@amsterdamumc.nl",
+            authorsInstitutions=[[1]],
+            namespaces=[omero.constants.namespaces.NSDYNAMIC],
+        )
+
+        try:
+            conn = BlitzGateway(client_obj=client)
+            script_params = client.getInputs(unwrap=True)
+
+            annotation_id = script_params[constants.file_transfer.FILE_ANNOTATION_ID]
+            folder_name = script_params[constants.file_transfer.FOLDER]
+            cleanup = script_params.get(constants.CLEANUP, True)
+
+            slurm_path, message = transfer_file_to_slurm(
+                conn=conn,
+                annotation_id=annotation_id,
+                folder_name=folder_name,
+                slurmClient=slurmClient,
+                cleanup=cleanup,
+            )
+
+            client.setOutput("Message", rstring(message))
+            client.setOutput("Slurm_Path", rstring(slurm_path))
+
+        except Exception as exc:
+            logger.exception("File transfer failed")
+            client.setOutput("Message", rstring(f"ERROR: {exc}"))
+
+        finally:
+            client.closeSession()
+
+
+if __name__ == "__main__":
+    # Some defaults from OMERO; don't feel like reading ice files.
+    # Retrieve the value of the OMERODIR environment variable
+    OMERODIR = os.environ.get('OMERODIR', '/opt/omero/server/OMERO.server')
+    LOGDIR = os.path.join(OMERODIR, 'var', 'log')
+    LOGFORMAT = "%(asctime)s %(levelname)-5.5s [%(name)40s] " \
+                "[%(process)d] (%(threadName)-10s) %(message)s"
+    # Added the process id
+    LOGSIZE = 500000000
+    LOGNUM = 9
+    log_filename = 'biomero.log'
+    # Create a stream handler with INFO level (for OMERO.web output)
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setLevel(logging.INFO)
+    # Create DEBUG logging to rotating logfile at var/log
+    logging.basicConfig(level=logging.DEBUG,
+                        format=LOGFORMAT,
+                        handlers=[
+                            stream_handler,
+                            logging.handlers.RotatingFileHandler(
+                                os.path.join(LOGDIR, log_filename),
+                                maxBytes=LOGSIZE,
+                                backupCount=LOGNUM)
+                        ])
+
+    # Silence some of the DEBUG - Extended for cleaner BIOMERO logs
+    logging.getLogger('omero.gateway.utils').setLevel(logging.WARNING)
+    logging.getLogger('omero.gateway').setLevel(logging.WARNING)  # Silences proxy creation spam
+    logging.getLogger('omero.client').setLevel(logging.WARNING)
+    logging.getLogger('paramiko.transport').setLevel(logging.WARNING)
+    logging.getLogger('paramiko.sftp').setLevel(logging.WARNING)
+    logging.getLogger('urllib3').setLevel(logging.WARNING)
+    logging.getLogger('requests').setLevel(logging.WARNING)
+    logging.getLogger('requests_cache').setLevel(logging.WARNING)  # Cache logs
+    logging.getLogger('requests-cache').setLevel(logging.WARNING)  # Alt naming
+    logging.getLogger('requests_cache.core').setLevel(logging.WARNING)  # Core module
+    logging.getLogger('requests_cache.backends').setLevel(logging.WARNING)
+    logging.getLogger('requests_cache.backends.base').setLevel(logging.WARNING)
+    logging.getLogger('requests_cache.backends.sqlite').setLevel(
+        logging.WARNING)
+    logging.getLogger('requests_cache.policy').setLevel(logging.WARNING)
+    logging.getLogger('requests_cache.policy.actions').setLevel(
+        logging.WARNING)
+    logging.getLogger('invoke').setLevel(logging.WARNING)
+    logging.getLogger('fabric').setLevel(logging.WARNING)  # SSH operations
+    logging.getLogger('Ice').setLevel(logging.ERROR)
+    logging.getLogger('ZeroC').setLevel(logging.ERROR)
+
+    run_script()

--- a/_data/_SLURM_Image_Transfer.py
+++ b/_data/_SLURM_Image_Transfer.py
@@ -104,7 +104,7 @@ def compress(target, base):
         target (str): Name of the zip file to write (e.g., "folder.zip").
         base (str): Name of folder to zip up (e.g., "folder").
     """
-    base_name, ext = target.split(".")
+    base_name, ext = target.rsplit(".", 1)
     shutil.make_archive(base_name, ext, base)
 
 

--- a/_data/_SLURM_Image_Transfer.py
+++ b/_data/_SLURM_Image_Transfer.py
@@ -76,7 +76,7 @@ import sys
 logger = logging.getLogger(__name__)
 
 # Version constant for easy version management
-VERSION = "2.6.0"
+VERSION = "2.7.0"
 
 # keep track of log strings.
 log_strings = []

--- a/admin/Example_Minimal_Slurm_Script.py
+++ b/admin/Example_Minimal_Slurm_Script.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Original work Copyright (C) 2014 University of Dundee
+#                                   & Open Microscopy Environment.
+#                    All Rights Reserved.
+# Modified work Copyright 2022 Torec Luik, Amsterdam UMC
+# Use is subject to license terms supplied in LICENSE.txt
+#
+
+from __future__ import print_function
+from omero.rtypes import rstring
+import omero.scripts as omscripts
+import omero
+import re
+import subprocess
+from biomero import SlurmClient
+from omero.gateway import BlitzGateway
+import logging
+import os
+import sys
+
+logger = logging.getLogger(__name__)
+
+_MAX_CMD_LENGTH = 500
+
+# Block destructive or dangerous command patterns even for admins
+_DANGEROUS_PATTERNS = [
+    r"\brm\b",           # rm (remove files)
+    r"\brmdir\b",        # rmdir
+    r"\bmkfs\b",         # format filesystem
+    r"\bdd\b",           # disk dump/overwrite
+    r"\bkill\b",         # kill processes
+    r"\bpkill\b",        # kill by name
+    r"\bscancel\b",      # cancel Slurm jobs
+    r"\breboot\b",       # reboot node
+    r"\bshutdown\b",     # shutdown node
+    r"\bpoweroff\b",     # poweroff node
+    r"\btruncate\b",     # truncate files
+    r"\bchmod\b",        # change permissions
+    r"\bchown\b",        # change ownership
+    r">\s*/",            # redirect to root path
+    r"\|\s*sh\b",        # pipe to shell
+    r"\|\s*bash\b",      # pipe to bash
+    r"\beval\b",         # eval arbitrary code
+    r"\bexec\b",         # replace process
+]
+
+
+def _check_command_safety(cmd: str) -> str | None:
+    """Return an error message if the command matches a dangerous pattern."""
+    if len(cmd) > _MAX_CMD_LENGTH:
+        return (f"Command too long ({len(cmd)} chars, max {_MAX_CMD_LENGTH}). "
+                f"Refusing to run.")
+    for pattern in _DANGEROUS_PATTERNS:
+        if re.search(pattern, cmd, re.IGNORECASE):
+            return (f"Command blocked: matches dangerous pattern '{pattern}'. "
+                    f"If you need this, run it directly on the Slurm cluster.")
+    return None
+
+
+_RUNSLRM = "Check_SLURM_Status"
+_SQUEUE = "Check_Queue"
+_SINFO = "Check_Cluster"
+_SOTHER = "Run_Other_Command"
+_SCMD = "Linux_Command"
+_DEFAULT_SCMD = "ls -la"
+
+VERSION = "2.0.0"
+
+
+def runScript():
+    """
+    The main entry point of the script
+    """
+    client = omscripts.client(
+        'Slurm SSH Command (Admin Only)',
+        '''Run SSH commands on the Slurm cluster.
+
+        **ADMIN ONLY**: This script requires OMERO administrator privileges.
+        ''',
+        omscripts.Bool(_RUNSLRM, grouping="01", default=True,
+                       description="Run Slurm status commands"),
+        omscripts.Bool(_SQUEUE, grouping="01.1", default=True,
+                       description="Show job queue (squeue -u $USER)"),
+        omscripts.Bool(_SINFO, grouping="01.2", default=False,
+                       description="Show cluster info (sinfo)"),
+        omscripts.Bool(_SOTHER, grouping="02", default=False,
+                       description="Run a custom Linux command on Slurm"),
+        omscripts.String(_SCMD, optional=True, grouping="02.1",
+                         description="The Linux command to run on Slurm",
+                         default=_DEFAULT_SCMD),
+        namespaces=[omero.constants.namespaces.NSDYNAMIC],
+        version=VERSION,
+        authors=["Torec Luik"],
+        institutions=["Amsterdam UMC"],
+        contact='cellularimaging@amsterdamumc.nl',
+        authorsInstitutions=[[1]]
+    )
+
+    try:
+        conn = BlitzGateway(client_obj=client)
+        user = conn.getUser()
+        is_admin = user.isAdmin()
+        user_id = conn.getUserId()
+
+        logger.info(f"User ID {user_id} admin status: {is_admin}")
+
+        if not is_admin:
+            logger.warning("Access denied: Admin privileges required")
+            client.setOutput("Message", rstring(
+                f"ACCESS DENIED: This script requires OMERO administrator "
+                f"privileges. User ID {user_id} is not an admin."
+            ))
+            return
+
+        scriptParams = client.getInputs(unwrap=True)
+        logger.info(f"Params: {scriptParams}")
+
+        user_name = user.getName()
+
+        with SlurmClient.from_config() as slurmClient:
+            logger.info(f"Slurm connection valid: {slurmClient.validate()}")
+
+            cmdlist = []
+            if scriptParams.get(_RUNSLRM):
+                if scriptParams.get(_SQUEUE):
+                    cmdlist.append("squeue -u $USER")
+                if scriptParams.get(_SINFO):
+                    cmdlist.append("sinfo")
+            if scriptParams.get(_SOTHER):
+                custom_cmd = scriptParams.get(_SCMD, "").strip()
+                safety_error = _check_command_safety(custom_cmd)
+                if safety_error:
+                    logger.warning(
+                        f"BLOCKED command from admin user {user_name} "
+                        f"(id={user_id}): '{custom_cmd}' — {safety_error}"
+                    )
+                    client.setOutput("Message", rstring(
+                        f"Command blocked: {safety_error}"
+                    ))
+                    return
+                cmdlist.append(custom_cmd)
+
+            print_result = []
+            try:
+                for cmd in cmdlist:
+                    # Audit: log who ran what
+                    logger.info(
+                        f"AUDIT: user={user_name} (id={user_id}) "
+                        f"running command: {cmd}"
+                    )
+                    results = slurmClient.run(cmd)
+                    logger.info(f"Ran slurm: {results}")
+                    print_result.append(str(results))
+            except Exception as e:
+                logger.error(f"Command error: {e}")
+                print_result.append(f"Error: {e}")
+
+            client.setOutput("Message", rstring("\n".join(print_result)))
+
+    finally:
+        client.closeSession()
+
+
+if __name__ == '__main__':
+    # Some defaults from OMERO; don't feel like reading ice files.
+    # Retrieve the value of the OMERODIR environment variable
+    OMERODIR = os.environ.get('OMERODIR', '/opt/omero/server/OMERO.server')
+    LOGDIR = os.path.join(OMERODIR, 'var', 'log')
+    LOGFORMAT = "%(asctime)s %(levelname)-5.5s [%(name)40s] " \
+                "[%(process)d] (%(threadName)-10s) %(message)s"
+    # Added the process id
+    LOGSIZE = 500000000
+    LOGNUM = 9
+    log_filename = 'biomero.log'
+    # Create a stream handler with INFO level (for OMERO.web output)
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setLevel(logging.INFO)
+    # Create DEBUG logging to rotating logfile at var/log
+    logging.basicConfig(level=logging.DEBUG,
+                        format=LOGFORMAT,
+                        handlers=[
+                            stream_handler,
+                            logging.handlers.RotatingFileHandler(
+                                os.path.join(LOGDIR, log_filename),
+                                maxBytes=LOGSIZE,
+                                backupCount=LOGNUM)
+                        ])
+       
+    # Silence some of the DEBUG
+    logging.getLogger('omero.gateway.utils').setLevel(logging.WARNING)
+    logging.getLogger('paramiko.transport').setLevel(logging.WARNING)
+
+    runScript()

--- a/admin/Example_Minimal_Slurm_Script.py
+++ b/admin/Example_Minimal_Slurm_Script.py
@@ -66,7 +66,7 @@ _SOTHER = "Run_Other_Command"
 _SCMD = "Linux_Command"
 _DEFAULT_SCMD = "ls -la"
 
-VERSION = "2.0.0"
+VERSION = "2.7.0"
 
 
 def runScript():

--- a/admin/SLURM_Init_environment.py
+++ b/admin/SLURM_Init_environment.py
@@ -37,7 +37,7 @@ import os
 import sys
 
 logger = logging.getLogger(__name__)
-VERSION = "2.6.0"
+VERSION = "2.7.0"
 
 
 def runScript():

--- a/admin/SLURM_check_setup.py
+++ b/admin/SLURM_check_setup.py
@@ -58,7 +58,7 @@ import sys
 import pkg_resources
 
 # Version constant for easy version management
-VERSION = "2.6.0"
+VERSION = "2.7.0"
 
 logger = logging.getLogger(__name__)
 

--- a/admin/Tail_logs.py
+++ b/admin/Tail_logs.py
@@ -26,7 +26,7 @@ _TAIL_LINES = "Tail_Lines"
 _DEFAULT_TAIL_LINES = 5000
 
 # Version constant for easy version management
-VERSION = "2.6.0"
+VERSION = "2.7.0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the Slurm workflow scripts, focusing on parameter type handling, error handling, and robustness. It also adds a new admin-only script for executing safe Slurm commands via OMERO. The most important changes are grouped below:

**Parameter Type Handling and Workflow Descriptor Improvements:**

* Replaces usage of `convert_cytype_to_omtype` with `convert_param_type_to_omtype` and consistently reads the parameter type from the `type` key instead of `cytype` in workflow parameter processing in `SLURM_CellPose_Segmentation.py`, `SLURM_Run_Workflow.py`, and `SLURM_Run_Workflow_Batched.py`. This improves compatibility with updated parameter schemas. [[1]](diffhunk://#diff-d18b6557fdb5749609aa6ecff406000e68f43c7c293a701f1bad4b455186fea4L141-R142) [[2]](diffhunk://#diff-27a964e3d3c04afded0e6976f7bbecd34380b4acc2d30e95be7e43d6338c2177L408-R416) [[3]](diffhunk://#diff-0dddb8086808af89eda841c9fd92de8632811582938fb079ae51fe1e9b85bc7cL254-R256)
* Updates workflow descriptor fetching to use `generic_descriptor_from_github` instead of `pull_descriptor_from_github`, and consistently accesses descriptor fields, improving maintainability and reducing ambiguity. [[1]](diffhunk://#diff-27a964e3d3c04afded0e6976f7bbecd34380b4acc2d30e95be7e43d6338c2177L385-R391) [[2]](diffhunk://#diff-0dddb8086808af89eda841c9fd92de8632811582938fb079ae51fe1e9b85bc7cL232-R238)

**Robustness and Error Handling:**

* Adds a pre-flight check in `run_workflow` to verify that the job script exists on the Slurm cluster before submitting a workflow, providing a clear error if the script is missing.
* Improves job status polling by initializing the job status dictionary before querying and logging transient errors as warnings instead of failing the workflow immediately, making job monitoring more resilient.
* Ensures all workflow parameters from other workflows are marked as optional, preventing them from blocking execution if not provided.

**Bug Fixes:**

* Fixes a bug in `_SLURM_Image_Transfer.py` where splitting the target filename for zipping now correctly handles filenames with multiple periods by using `rsplit(".", 1)`.

**New Admin Script:**

* Adds `admin/Example_Minimal_Slurm_Script.py`, a secure admin-only OMERO script for running selected Slurm or Linux commands on the cluster. It includes comprehensive safety checks to block dangerous commands, detailed logging, and user/admin validation to ensure only authorized actions are performed.